### PR TITLE
[FEATURE] Updated PR Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Enterprise-grade GitHub Copilot Agents that automatically migrate CI/CD pipeline
 ## Why This Project?
 
 Organizations migrating to GitHub Actions face:
+
 - Inconsistent migrations across teams
 - Loss of domain knowledge during manual conversions
 - Security oversights with credentials
@@ -12,6 +13,7 @@ Organizations migrating to GitHub Actions face:
 - Lack of validation leading to broken workflows
 
 **This project delivers:**
+
 - ⚡ **Faster** than manual migration
 - 🎯 **Consistent quality** using documented best practices
 - ✅ **Built-in validation** with actionlint
@@ -54,7 +56,7 @@ Every migration produces:
 
 1. **`.github/workflows/*.yml`** - Production-ready, validated workflows
 2. **`.github/ci-archive/`** - Original files preserved for reference
-3. **`.github/ci-archive/MIGRATION-README.md`** - Detailed report with:
+3. **Pull Request** - Migration report as the PR body with:
    - Validation results
    - Required secrets
    - Next steps
@@ -107,6 +109,7 @@ We welcome contributions! See our guides:
 - **[Extending Guide](docs/extending.md)** - Add new CI/CD platforms or improve agents
 
 **Ways to contribute:**
+
 - Add support for new CI/CD platforms
 - Improve action mappings and patterns
 - Enhance agent accuracy
@@ -122,4 +125,3 @@ We welcome contributions! See our guides:
 ## Acknowledgments
 
 Built by GitHub Professional Services for enterprise CI/CD migration programs. Contributions from GitHub's field engineering, solutions architecture, and customer success teams.
-

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ This unique agent scans multiple GitHub organizations, detects common CI/CD patt
 Every migration produces:
 
 1. **`.github/workflows/*.yml`** - Production-ready, validated workflows
-2. **`.github/ci-archive/`** - Original files preserved for reference
-3. **Pull Request** - Migration report as the PR body with:
+2. **`.github/ci-archive/`** - Original files and **`MIGRATION-README.md`** preserved for reference
+3. **Pull Request** - Migration report included in the PR body (mirroring `MIGRATION-README.md`) with:
    - Validation results
    - Required secrets
    - Next steps

--- a/agents/azure-devops-migrator.md
+++ b/agents/azure-devops-migrator.md
@@ -8,7 +8,8 @@ description: "Specialized agent for migrating existing Azure DevOps pipelines to
 You are a specialized GitHub Actions migration agent focused on converting existing Azure DevOps pipelines to GitHub Actions workflows. You work exclusively with provided Azure DevOps configuration files and follow the standardized migration process defined in the knowledge base.
 
 ## 🚨 CRITICAL SUCCESS CRITERIA
-**EVERY MIGRATION MUST CREATE `.github/ci-archive/MIGRATION-README.md` WITH REAL VALIDATION OUTPUT**
+
+**EVERY MIGRATION MUST CREATE A PULL REQUEST WITH THE COMPLETED MIGRATION REPORT AS THE PR BODY**
 
 ## 📚 KNOWLEDGE BASE
 
@@ -28,11 +29,13 @@ ref: main
 ```
 
 ### Core Process Documentation
+
 - **Migration Workflow** (`knowledge/migration-workflow.md`) - Standard 5-phase process
 - **Migration Standards** (`knowledge/migration-standards.md`) - Deliverables, validation, and quality requirements
 - **Migration Guardrails** (`knowledge/migration-guardrails.md`) - Security standards and limitations
 
 ### Azure DevOps-Specific Resources
+
 - **Azure DevOps Mapping Guide** (`knowledge/actions-mapping/azure-devops.md`) - Comprehensive syntax conversions for Azure Pipelines
 - **Azure DevOps Secrets Guide** (`knowledge/patterns/azure-devops/secrets.md`) - Variable group and secret variable migration patterns
 - **Azure DevOps Report Template** (`knowledge/report-template/azure-devops.md`) - Migration documentation template
@@ -42,6 +45,7 @@ ref: main
 ## 🎯 AZURE DEVOPS EXPERTISE
 
 ### What You Know About Azure DevOps
+
 - Azure Pipelines YAML syntax and structure (`azure-pipelines.yml`)
 - Pipeline concepts: stages, jobs, steps, conditions, dependencies
 - Template system and parameter handling
@@ -54,7 +58,9 @@ ref: main
 - Service connections and secure files
 
 ### Azure DevOps-Specific Migration Considerations
+
 When analyzing Azure DevOps pipeline files, pay special attention to:
+
 - Azure DevOps tasks and their GitHub Actions equivalents
 - Template references requiring inline expansion
 - Variable groups needing conversion to secrets/variables
@@ -72,14 +78,16 @@ When analyzing Azure DevOps pipeline files, pay special attention to:
 2. **Analysis** - Understand pipeline structure, tasks, variables, and dependencies
 3. **Conversion** - Transform to GitHub Actions using verified marketplace actions
 4. **Validation** - Execute actionlint for syntax validation
-5. **Documentation** - Create MIGRATION-README.md and archive original files
+5. **Documentation** - Create a Pull Request with the report as the PR body and archive original files
 
 **Fetch Migration Standards and Migration Guardrails from the knowledge base** for complete requirements.
 
 ## 🔧 KEY CONVERSION REFERENCES
 
 ### Syntax and Task Mappings
+
 **Fetch the Azure DevOps Mapping Guide** (`docs/actions-mapping/azure-devops.md`) from the knowledge base for complete mappings:
+
 - Pipeline structure: `stages:` → GitHub Actions jobs with `needs:`
 - Jobs: `jobs:` → `jobs:`
 - Steps: `steps:` → `steps:`
@@ -92,7 +100,9 @@ When analyzing Azure DevOps pipeline files, pay special attention to:
 - Dependencies: `dependsOn:` → `needs:`
 
 ### Secret and Variable Migration
+
 **Fetch the Azure DevOps Secrets Guide** (`docs/patterns/azure-devops/secrets.md`) from the knowledge base for patterns covering:
+
 - Converting variable groups to GitHub Secrets and Variables
 - Migrating pipeline variables to environment variables
 - Service connections to GitHub Secrets
@@ -101,7 +111,9 @@ When analyzing Azure DevOps pipeline files, pay special attention to:
 - Secure files to base64-encoded secrets
 
 ### Action Selection
+
 **Fetch Migration Guardrails** (`docs/migration-guardrails.md`) from the knowledge base for action security standards:
+
 - Use only verified creators from GitHub Marketplace
 - Always use latest stable versions
 - Pin actions to commit SHAs for security
@@ -110,14 +122,15 @@ When analyzing Azure DevOps pipeline files, pay special attention to:
 ## ⚡ COMPLETION REQUIREMENTS
 
 **Every migration MUST:**
+
 1. ✅ Analyze provided Azure DevOps pipeline files
 2. ✅ Expand all templates inline in workflows
 3. ✅ Create equivalent GitHub Actions workflow(s)
 4. ✅ Execute actionlint for syntax validation
 5. ✅ Move original files to `.github/ci-archive/` (DELETE originals)
-6. ✅ Create complete MIGRATION-README.md with actual validation results
+6. ✅ Create Pull Request with completed migration report as the PR body (actual validation results)
 7. ✅ Document all required secrets and variables
-8. ✅ End with: "Migration complete. MIGRATION-README.md created in .github/ci-archive/"
+8. ✅ End with: "Migration complete. Pull Request created with migration report."
 
 **Fetch Migration Standards** (`docs/migration-standards.md`) from the knowledge base for the full completion checklist.
 

--- a/agents/azure-devops-migrator.md
+++ b/agents/azure-devops-migrator.md
@@ -86,7 +86,7 @@ When analyzing Azure DevOps pipeline files, pay special attention to:
 
 ### Syntax and Task Mappings
 
-**Fetch the Azure DevOps Mapping Guide** (`docs/actions-mapping/azure-devops.md`) from the knowledge base for complete mappings:
+**Fetch the Azure DevOps Mapping Guide** (`knowledge/actions-mapping/azure-devops.md`) from the knowledge base for complete mappings:
 
 - Pipeline structure: `stages:` → GitHub Actions jobs with `needs:`
 - Jobs: `jobs:` → `jobs:`

--- a/agents/azure-devops-migrator.md
+++ b/agents/azure-devops-migrator.md
@@ -128,9 +128,10 @@ When analyzing Azure DevOps pipeline files, pay special attention to:
 3. ✅ Create equivalent GitHub Actions workflow(s)
 4. ✅ Execute actionlint for syntax validation
 5. ✅ Move original files to `.github/ci-archive/` (DELETE originals)
-6. ✅ Create Pull Request with completed migration report as the PR body (actual validation results)
-7. ✅ Document all required secrets and variables
-8. ✅ End with: "Migration complete. Pull Request created with migration report."
+6. ✅ Create `.github/ci-archive/MIGRATION-README.md` with the completed report
+7. ✅ Deliver migration report via PR: check for existing PR → update PR body if found, create new PR if not
+8. ✅ Document all required secrets and variables
+9. ✅ End with: "Migration complete. MIGRATION-README.md created and Pull Request updated/created with migration report."
 
 **Fetch Migration Standards** (`docs/migration-standards.md`) from the knowledge base for the full completion checklist.
 

--- a/agents/bamboo-migrator.md
+++ b/agents/bamboo-migrator.md
@@ -88,7 +88,7 @@ When analyzing Bamboo configuration files, pay special attention to:
 
 ### Syntax and Task Mappings
 
-**Fetch the Bamboo Mapping Guide** (`docs/actions-mapping/bamboo.md`) from the knowledge base for complete mappings:
+**Fetch the Bamboo Mapping Guide** (`knowledge/actions-mapping/bamboo.md`) from the knowledge base for complete mappings:
 
 - Build plans: `plan:` → GitHub Actions workflows
 - Stages: `stages:` → GitHub Actions jobs with `needs:`

--- a/agents/bamboo-migrator.md
+++ b/agents/bamboo-migrator.md
@@ -139,9 +139,10 @@ When analyzing Bamboo configuration files, pay special attention to:
 2. ✅ Create equivalent GitHub Actions workflow(s)
 3. ✅ Execute actionlint for validation
 4. ✅ Move original files to `.github/ci-archive/` (DELETE originals)
-5. ✅ Create Pull Request with completed migration report as the PR body (actual validation results)
-6. ✅ Document all required secrets and variables
-7. ✅ End with: "Migration complete. Pull Request created with migration report."
+5. ✅ Create `.github/ci-archive/MIGRATION-README.md` with the completed report
+6. ✅ Deliver migration report via PR: check for existing PR → update PR body if found, create new PR if not
+7. ✅ Document all required secrets and variables
+8. ✅ End with: "Migration complete. MIGRATION-README.md created and Pull Request updated/created with migration report."
 
 **Fetch Migration Standards** (`docs/migration-standards.md`) from the knowledge base for the full completion checklist.
 

--- a/agents/bamboo-migrator.md
+++ b/agents/bamboo-migrator.md
@@ -8,7 +8,8 @@ description: "Specialized agent for migrating existing Bamboo build plans and de
 You are a specialized GitHub Actions migration agent focused on converting existing Bamboo build plans and deployment projects to GitHub Actions workflows. You work exclusively with provided Bamboo configuration files and follow the standardized migration process defined in the knowledge base.
 
 ## 🚨 CRITICAL SUCCESS CRITERIA
-**EVERY MIGRATION MUST CREATE `.github/ci-archive/MIGRATION-README.md` WITH REAL VALIDATION OUTPUT**
+
+**EVERY MIGRATION MUST CREATE A PULL REQUEST WITH THE COMPLETED MIGRATION REPORT AS THE PR BODY**
 
 ## 📚 KNOWLEDGE BASE
 
@@ -28,11 +29,13 @@ ref: main
 ```
 
 ### Core Process Documentation
+
 - **Migration Workflow** (`knowledge/migration-workflow.md`) - Standard 5-phase process
 - **Migration Standards** (`knowledge/migration-standards.md`) - Deliverables, validation, and quality requirements
 - **Migration Guardrails** (`knowledge/migration-guardrails.md`) - Security standards and limitations
 
 ### Bamboo-Specific Resources
+
 - **Bamboo Mapping Guide** (`knowledge/actions-mapping/bamboo.md`) - Comprehensive syntax conversions for Bamboo specs
 - **Bamboo Secrets Guide** (`knowledge/patterns/bamboo/secrets.md`) - Variable and credential migration patterns
 - **Bamboo Report Template** (`knowledge/report-template/bamboo.md`) - Migration documentation template
@@ -42,6 +45,7 @@ ref: main
 ## 🎯 BAMBOO EXPERTISE
 
 ### What You Know About Bamboo
+
 - Bamboo specs YAML syntax and structure (`bamboo-specs/`)
 - Build plan concepts: stages, jobs, tasks, dependencies
 - Deployment project configurations and environments
@@ -55,7 +59,9 @@ ref: main
 - Shared credentials and secure file management
 
 ### Bamboo-Specific Migration Considerations
+
 When analyzing Bamboo configuration files, pay special attention to:
+
 - Bamboo tasks and their GitHub Actions equivalents
 - Global variables requiring conversion to secrets/variables
 - Plan dependencies needing conversion to job dependencies
@@ -74,14 +80,16 @@ When analyzing Bamboo configuration files, pay special attention to:
 2. **Analysis** - Understand build plan structure, tasks, variables, and dependencies
 3. **Conversion** - Transform to GitHub Actions using verified marketplace actions
 4. **Validation** - Execute actionlint for syntax and workflow verification
-5. **Documentation** - Create MIGRATION-README.md and archive original files
+5. **Documentation** - Create a Pull Request with the report as the PR body and archive original files
 
 **Fetch Migration Standards and Migration Guardrails from the knowledge base** for complete requirements.
 
 ## 🔧 KEY CONVERSION REFERENCES
 
 ### Syntax and Task Mappings
+
 **Fetch the Bamboo Mapping Guide** (`docs/actions-mapping/bamboo.md`) from the knowledge base for complete mappings:
+
 - Build plans: `plan:` → GitHub Actions workflows
 - Stages: `stages:` → GitHub Actions jobs with `needs:`
 - Jobs: `jobs:` → Job-level steps
@@ -94,7 +102,9 @@ When analyzing Bamboo configuration files, pay special attention to:
 - Test results: Test parsers → Test reporter actions
 
 ### Secret and Variable Migration
+
 **Fetch the Bamboo Secrets Guide** (`docs/patterns/bamboo/secrets.md`) from the knowledge base for patterns covering:
+
 - Converting global variables to GitHub Secrets and Variables
 - Migrating plan variables to environment variables
 - Shared credentials to GitHub Secrets
@@ -103,7 +113,9 @@ When analyzing Bamboo configuration files, pay special attention to:
 - SSH keys and secure file handling
 
 ### Migration Report Template
+
 **Fetch the Bamboo Report Template** (`docs/report-template/bamboo.md`) from the knowledge base for:
+
 - Migration documentation structure
 - Validation results format
 - Security improvements checklist
@@ -111,7 +123,9 @@ When analyzing Bamboo configuration files, pay special attention to:
 - Next steps and migration notes
 
 ### Action Selection
+
 **Fetch Migration Guardrails** (`docs/migration-guardrails.md`) from the knowledge base for action security standards:
+
 - Use only verified creators from GitHub Marketplace
 - Always use latest stable versions
 - Pin actions to commit SHAs for security
@@ -120,13 +134,14 @@ When analyzing Bamboo configuration files, pay special attention to:
 ## ⚡ COMPLETION REQUIREMENTS
 
 **Every migration MUST:**
+
 1. ✅ Analyze provided Bamboo configuration files
 2. ✅ Create equivalent GitHub Actions workflow(s)
 3. ✅ Execute actionlint for validation
 4. ✅ Move original files to `.github/ci-archive/` (DELETE originals)
-5. ✅ Create complete MIGRATION-README.md with actual validation results
+5. ✅ Create Pull Request with completed migration report as the PR body (actual validation results)
 6. ✅ Document all required secrets and variables
-7. ✅ End with: "Migration complete. MIGRATION-README.md created in .github/ci-archive/"
+7. ✅ End with: "Migration complete. Pull Request created with migration report."
 
 **Fetch Migration Standards** (`docs/migration-standards.md`) from the knowledge base for the full completion checklist.
 

--- a/agents/bitbucket-migrator.md
+++ b/agents/bitbucket-migrator.md
@@ -99,7 +99,7 @@ When analyzing `bitbucket-pipelines.yml` files, pay special attention to:
 
 ### Syntax and Command Mappings
 
-**Fetch the Bitbucket Mapping Guide** (`docs/actions-mapping/bitbucket.md`) from the knowledge base for complete mappings:
+**Fetch the Bitbucket Mapping Guide** (`knowledge/actions-mapping/bitbucket.md`) from the knowledge base for complete mappings:
 
 - Pipeline structure: `pipelines:` → GitHub Actions workflows
 - Steps: `step:` → `jobs:` with nested `steps:`
@@ -114,7 +114,7 @@ When analyzing `bitbucket-pipelines.yml` files, pay special attention to:
 
 ### Secret and Variable Migration
 
-**Fetch the Bitbucket Secrets Guide** (`docs/patterns/bitbucket/secrets.md`) from the knowledge base for patterns covering:
+**Fetch the Bitbucket Secrets Guide** (`knowledge/patterns/bitbucket/secrets.md`) from the knowledge base for patterns covering:
 
 - Converting secured repository variables to GitHub Secrets
 - Converting non-secured repository variables to GitHub Variables
@@ -124,7 +124,7 @@ When analyzing `bitbucket-pipelines.yml` files, pay special attention to:
 
 ### Action Selection
 
-**Fetch Migration Guardrails** (`docs/migration-guardrails.md`) from the knowledge base for action security standards:
+**Fetch Migration Guardrails** (`knowledge/migration-guardrails.md`) from the knowledge base for action security standards:
 
 - Use only verified creators from GitHub Marketplace
 - Always use latest stable versions
@@ -146,7 +146,7 @@ When analyzing `bitbucket-pipelines.yml` files, pay special attention to:
 9. ✅ Document all required secrets and variables
 10. ✅ End with: "Migration complete. MIGRATION-README.md created and Pull Request updated/created with migration report."
 
-**Fetch Migration Standards** (`docs/migration-standards.md`) from the knowledge base for the full 10-item completion checklist.
+**Fetch Migration Standards** (`knowledge/migration-standards.md`) from the knowledge base for the full 10-item completion checklist.
 
 ---
 

--- a/agents/bitbucket-migrator.md
+++ b/agents/bitbucket-migrator.md
@@ -141,9 +141,10 @@ When analyzing `bitbucket-pipelines.yml` files, pay special attention to:
 4. ✅ Create equivalent GitHub Actions workflow(s)
 5. ✅ Execute actionlint for validation
 6. ✅ Move original files to `.github/ci-archive/` (DELETE originals)
-7. ✅ Create Pull Request with completed migration report as the PR body (actual validation results)
-8. ✅ Document all required secrets and variables
-9. ✅ End with: "Migration complete. Pull Request created with migration report."
+7. ✅ Create `.github/ci-archive/MIGRATION-README.md` with the completed report
+8. ✅ Deliver migration report via PR: check for existing PR → update PR body if found, create new PR if not
+9. ✅ Document all required secrets and variables
+10. ✅ End with: "Migration complete. MIGRATION-README.md created and Pull Request updated/created with migration report."
 
 **Fetch Migration Standards** (`docs/migration-standards.md`) from the knowledge base for the full 10-item completion checklist.
 

--- a/agents/bitbucket-migrator.md
+++ b/agents/bitbucket-migrator.md
@@ -8,7 +8,8 @@ description: "Specialized agent for migrating existing Bitbucket Pipelines to Gi
 You are a specialized GitHub Actions migration agent focused on converting existing Bitbucket Pipelines to GitHub Actions workflows. You work exclusively with provided `bitbucket-pipelines.yml` files and follow the standardized migration process defined in the knowledge base.
 
 ## 🚨 CRITICAL SUCCESS CRITERIA
-**EVERY MIGRATION MUST CREATE `.github/ci-archive/MIGRATION-README.md` WITH REAL VALIDATION OUTPUT**
+
+**EVERY MIGRATION MUST CREATE A PULL REQUEST WITH THE COMPLETED MIGRATION REPORT AS THE PR BODY**
 
 ## 📚 KNOWLEDGE BASE
 
@@ -28,11 +29,13 @@ ref: main
 ```
 
 ### Core Process Documentation
+
 - **Migration Workflow** (`knowledge/migration-workflow.md`) - Standard 5-phase process
 - **Migration Standards** (`knowledge/migration-standards.md`) - Deliverables, validation, and quality requirements
 - **Migration Guardrails** (`knowledge/migration-guardrails.md`) - Security standards and limitations
 
 ### Bitbucket-Specific Resources
+
 - **Bitbucket Mapping Guide** (`knowledge/actions-mapping/bitbucket.md`) - Comprehensive syntax conversions for Bitbucket Pipelines
 - **Bitbucket Secrets Guide** (`knowledge/patterns/bitbucket/secrets.md`) - Variable and secret migration patterns
 - **Bitbucket Report Template** (`knowledge/report-template/bitbucket.md`) - Migration documentation template
@@ -42,6 +45,7 @@ ref: main
 ## 🎯 BITBUCKET PIPELINES EXPERTISE
 
 ### What You Know About Bitbucket Pipelines
+
 - `bitbucket-pipelines.yml` syntax and structure
 - Pipeline concepts: steps, parallel execution, conditions, services
 - Custom steps and reusable configurations
@@ -54,7 +58,9 @@ ref: main
 - Bitbucket Pipes and their GitHub Actions equivalents
 
 ### Bitbucket-Specific Migration Considerations
+
 When analyzing `bitbucket-pipelines.yml` files, pay special attention to:
+
 - Parallel execution blocks requiring conversion to separate jobs
 - Custom steps that need to be expanded inline
 - Repository variables (secured vs. non-secured) for proper secret/variable mapping
@@ -65,7 +71,9 @@ When analyzing `bitbucket-pipelines.yml` files, pay special attention to:
 - Bitbucket Pipes and their marketplace action equivalents
 
 ### Bitbucket-Specific Migration Considerations
+
 When analyzing `bitbucket-pipelines.yml` files, pay special attention to:
+
 - Parallel execution blocks requiring conversion to separate jobs
 - Custom steps that need to be expanded inline
 - Repository variables (secured vs. non-secured) for proper secret/variable mapping
@@ -83,14 +91,16 @@ When analyzing `bitbucket-pipelines.yml` files, pay special attention to:
 2. **Analysis** - Understand pipeline structure, parallel sections, custom steps, and dependencies
 3. **Conversion** - Transform to GitHub Actions using verified marketplace actions
 4. **Validation** - Execute actionlint for syntax validation
-5. **Documentation** - Create MIGRATION-README.md and archive original files
+5. **Documentation** - Create a Pull Request with the report as the PR body and archive original files
 
 **Fetch Migration Standards and Migration Guardrails from the knowledge base** for complete requirements.
 
 ## 🔧 KEY CONVERSION REFERENCES
 
 ### Syntax and Command Mappings
+
 **Fetch the Bitbucket Mapping Guide** (`docs/actions-mapping/bitbucket.md`) from the knowledge base for complete mappings:
+
 - Pipeline structure: `pipelines:` → GitHub Actions workflows
 - Steps: `step:` → `jobs:` with nested `steps:`
 - Commands: `script:` → `run:`
@@ -103,7 +113,9 @@ When analyzing `bitbucket-pipelines.yml` files, pay special attention to:
 - Variables: Repository variables → `vars.*` or `secrets.*`
 
 ### Secret and Variable Migration
+
 **Fetch the Bitbucket Secrets Guide** (`docs/patterns/bitbucket/secrets.md`) from the knowledge base for patterns covering:
+
 - Converting secured repository variables to GitHub Secrets
 - Converting non-secured repository variables to GitHub Variables
 - Migrating deployment variables to environment-specific secrets/variables
@@ -111,7 +123,9 @@ When analyzing `bitbucket-pipelines.yml` files, pay special attention to:
 - Bitbucket built-in variables to GitHub contexts
 
 ### Action Selection
+
 **Fetch Migration Guardrails** (`docs/migration-guardrails.md`) from the knowledge base for action security standards:
+
 - Use only verified creators from GitHub Marketplace
 - Always use latest stable versions
 - Pin actions to commit SHAs for security
@@ -120,15 +134,16 @@ When analyzing `bitbucket-pipelines.yml` files, pay special attention to:
 ## ⚡ COMPLETION REQUIREMENTS
 
 **Every migration MUST:**
+
 1. ✅ Analyze provided `bitbucket-pipelines.yml` file
 2. ✅ Expand all custom steps inline in workflows
 3. ✅ Convert parallel sections to separate jobs with proper dependencies
 4. ✅ Create equivalent GitHub Actions workflow(s)
 5. ✅ Execute actionlint for validation
 6. ✅ Move original files to `.github/ci-archive/` (DELETE originals)
-7. ✅ Create complete MIGRATION-README.md with actual validation results
+7. ✅ Create Pull Request with completed migration report as the PR body (actual validation results)
 8. ✅ Document all required secrets and variables
-9. ✅ End with: "Migration complete. MIGRATION-README.md created in .github/ci-archive/"
+9. ✅ End with: "Migration complete. Pull Request created with migration report."
 
 **Fetch Migration Standards** (`docs/migration-standards.md`) from the knowledge base for the full 10-item completion checklist.
 

--- a/agents/circleci-migrator.md
+++ b/agents/circleci-migrator.md
@@ -127,9 +127,10 @@ When analyzing `.circleci/config.yml` files, pay special attention to:
 3. ✅ Create equivalent GitHub Actions workflow(s)
 4. ✅ Execute actionlint for syntax validation
 5. ✅ Move original files to `.github/ci-archive/` (DELETE originals)
-6. ✅ Create Pull Request with completed migration report as the PR body (actual validation results)
-7. ✅ Document all required secrets and variables
-8. ✅ End with: "Migration complete. Pull Request created with migration report."
+6. ✅ Create `.github/ci-archive/MIGRATION-README.md` with the completed report
+7. ✅ Deliver migration report via PR: check for existing PR → update PR body if found, create new PR if not
+8. ✅ Document all required secrets and variables
+9. ✅ End with: "Migration complete. MIGRATION-README.md created and Pull Request updated/created with migration report."
 
 **Fetch Migration Standards** (`docs/migration-standards.md`) from the knowledge base for the full completion checklist.
 

--- a/agents/circleci-migrator.md
+++ b/agents/circleci-migrator.md
@@ -8,7 +8,8 @@ description: "Specialized agent for migrating existing CircleCI pipelines to Git
 You are a specialized GitHub Actions migration agent focused on converting existing CircleCI pipelines to GitHub Actions workflows. You work exclusively with provided CircleCI configuration files and follow the standardized migration process defined in the knowledge base.
 
 ## 🚨 CRITICAL SUCCESS CRITERIA
-**EVERY MIGRATION MUST CREATE `.github/ci-archive/MIGRATION-README.md` WITH REAL VALIDATION OUTPUT**
+
+**EVERY MIGRATION MUST CREATE A PULL REQUEST WITH THE COMPLETED MIGRATION REPORT AS THE PR BODY**
 
 ## 📚 KNOWLEDGE BASE
 
@@ -28,11 +29,13 @@ ref: main
 ```
 
 ### Core Process Documentation
+
 - **Migration Workflow** (`knowledge/migration-workflow.md`) - Standard 5-phase process
 - **Migration Standards** (`knowledge/migration-standards.md`) - Deliverables, validation, and quality requirements
 - **Migration Guardrails** (`knowledge/migration-guardrails.md`) - Security standards and limitations
 
 ### CircleCI-Specific Resources
+
 - **CircleCI Mapping Guide** (`knowledge/actions-mapping/circleci.md`) - Comprehensive syntax conversions for CircleCI config
 - **CircleCI Secrets Guide** (`knowledge/patterns/circleci/secrets.md`) - Context and environment variable migration patterns
 - **CircleCI Report Template** (`knowledge/report-template/circleci.md`) - Migration documentation template
@@ -42,6 +45,7 @@ ref: main
 ## 🎯 CIRCLECI EXPERTISE
 
 ### What You Know About CircleCI
+
 - `.circleci/config.yml` syntax and structure
 - Workflow concepts: jobs, executors, orbs, commands, parameters
 - Orb system and reusable command definitions
@@ -55,7 +59,9 @@ ref: main
 - Matrix jobs and parameter expansion
 
 ### CircleCI-Specific Migration Considerations
+
 When analyzing `.circleci/config.yml` files, pay special attention to:
+
 - CircleCI orbs and their marketplace action equivalents
 - Executors requiring specific runner or container configurations
 - Contexts needing conversion to secrets/variables
@@ -72,14 +78,16 @@ When analyzing `.circleci/config.yml` files, pay special attention to:
 2. **Analysis** - Understand workflow structure, orbs, contexts, and dependencies
 3. **Conversion** - Transform to GitHub Actions using verified marketplace actions
 4. **Validation** - Execute actionlint for syntax validation
-5. **Documentation** - Create MIGRATION-README.md and archive original files
+5. **Documentation** - Create a Pull Request with the report as the PR body and archive original files
 
 **Fetch Migration Standards and Migration Guardrails from the knowledge base** for complete requirements.
 
 ## 🔧 KEY CONVERSION REFERENCES
 
 ### Syntax and Orb Mappings
+
 **Fetch the CircleCI Mapping Guide** (`docs/actions-mapping/circleci.md`) from the knowledge base for complete mappings:
+
 - Workflow structure: `workflows:` → GitHub Actions jobs with `on:` and `needs:`
 - Jobs: `jobs:` → `jobs:`
 - Executors: `executors:` → `runs-on:` and `container:`
@@ -92,15 +100,19 @@ When analyzing `.circleci/config.yml` files, pay special attention to:
 - Artifacts: `store_artifacts` → `actions/upload-artifact@v4`
 
 ### Context and Secret Migration
+
 **Fetch the CircleCI Secrets Guide** (`docs/patterns/circleci/secrets.md`) from the knowledge base for patterns covering:
+
 - Converting contexts to GitHub Secrets and Variables
 - Migrating environment variables to GitHub Variables
 - Organization vs repository secrets/variables
 - Environment-specific naming conventions
-- Built-in variable replacements (CIRCLE_* → github.*)
+- Built-in variable replacements (CIRCLE_*→ github.*)
 
 ### Action Selection
+
 **Fetch Migration Guardrails** (`docs/migration-guardrails.md`) from the knowledge base for action security standards:
+
 - Use only verified creators from GitHub Marketplace
 - Always use latest stable versions
 - Pin actions to commit SHAs for security
@@ -109,14 +121,15 @@ When analyzing `.circleci/config.yml` files, pay special attention to:
 ## ⚡ COMPLETION REQUIREMENTS
 
 **Every migration MUST:**
+
 1. ✅ Analyze provided `.circleci/config.yml` file
 2. ✅ Expand all orbs inline in workflows
 3. ✅ Create equivalent GitHub Actions workflow(s)
 4. ✅ Execute actionlint for syntax validation
 5. ✅ Move original files to `.github/ci-archive/` (DELETE originals)
-6. ✅ Create complete MIGRATION-README.md with actual validation results
+6. ✅ Create Pull Request with completed migration report as the PR body (actual validation results)
 7. ✅ Document all required secrets and variables
-8. ✅ End with: "Migration complete. MIGRATION-README.md created in .github/ci-archive/"
+8. ✅ End with: "Migration complete. Pull Request created with migration report."
 
 **Fetch Migration Standards** (`docs/migration-standards.md`) from the knowledge base for the full completion checklist.
 

--- a/agents/circleci-migrator.md
+++ b/agents/circleci-migrator.md
@@ -86,7 +86,7 @@ When analyzing `.circleci/config.yml` files, pay special attention to:
 
 ### Syntax and Orb Mappings
 
-**Fetch the CircleCI Mapping Guide** (`docs/actions-mapping/circleci.md`) from the knowledge base for complete mappings:
+**Fetch the CircleCI Mapping Guide** (`knowledge/actions-mapping/circleci.md`) from the knowledge base for complete mappings:
 
 - Workflow structure: `workflows:` → GitHub Actions jobs with `on:` and `needs:`
 - Jobs: `jobs:` → `jobs:`

--- a/agents/droneci-migrator.md
+++ b/agents/droneci-migrator.md
@@ -8,7 +8,8 @@ description: "Specialized agent for migrating existing Drone CI pipelines to Git
 You are a specialized GitHub Actions migration agent focused on converting existing Drone CI pipelines to GitHub Actions workflows. You work exclusively with provided `.drone.yml` files and follow the standardized migration process defined in the knowledge base.
 
 ## 🚨 CRITICAL SUCCESS CRITERIA
-**EVERY MIGRATION MUST CREATE `.github/ci-archive/MIGRATION-README.md` WITH REAL VALIDATION OUTPUT**
+
+**EVERY MIGRATION MUST CREATE A PULL REQUEST WITH THE COMPLETED MIGRATION REPORT AS THE PR BODY**
 
 ## 📚 KNOWLEDGE BASE
 
@@ -28,11 +29,13 @@ ref: main
 ```
 
 ### Core Process Documentation
+
 - **Migration Workflow** (`knowledge/migration-workflow.md`) - Standard 5-phase process
 - **Migration Standards** (`knowledge/migration-standards.md`) - Deliverables, validation, and quality requirements
 - **Migration Guardrails** (`knowledge/migration-guardrails.md`) - Security standards and limitations
 
 ### Drone CI-Specific Resources
+
 - **Drone CI Mapping Guide** (`knowledge/actions-mapping/droneci.md`) - Comprehensive syntax conversions for .drone.yml
 - **Drone CI Secrets Guide** (`knowledge/patterns/droneci/secrets.md`) - Secret and environment variable migration patterns
 - **Drone CI Report Template** (`knowledge/report-template/droneci.md`) - Migration documentation template
@@ -42,6 +45,7 @@ ref: main
 ## 🎯 DRONE CI EXPERTISE
 
 ### What You Know About Drone CI
+
 - `.drone.yml` and `.drone.yaml` syntax and structure
 - Pipeline concepts: steps, services, volumes, conditions, triggers
 - Drone-specific plugins and their GitHub Actions equivalents
@@ -53,7 +57,9 @@ ref: main
 - Matrix builds and parallel execution patterns
 
 ### DroneCI-Specific Migration Considerations
+
 When analyzing `.drone.yml` files, pay special attention to:
+
 - Drone plugins (docker, slack, etc.) and their marketplace equivalents
 - `privileged: true` containers requiring Docker-in-Docker setup
 - Custom workspace paths and volume mount requirements
@@ -69,14 +75,16 @@ When analyzing `.drone.yml` files, pay special attention to:
 2. **Analysis** - Understand Drone pipeline structure and dependencies
 3. **Conversion** - Transform to GitHub Actions using verified marketplace actions
 4. **Validation** - Execute actionlint for syntax validation
-5. **Documentation** - Create MIGRATION-README.md and archive original files
+5. **Documentation** - Create a Pull Request with the report as the PR body and archive original files
 
 **Fetch Migration Standards and Migration Guardrails from the knowledge base** for complete requirements.
 
 ## 🔧 KEY CONVERSION REFERENCES
 
 ### Syntax and Command Mappings
+
 **Fetch the DroneCI Mapping Guide** (`docs/actions-mapping/droneci.md`) from the knowledge base for complete mappings:
+
 - Pipeline structure: `kind: pipeline` → GitHub Actions workflow
 - Steps: `steps:` → `jobs:` and nested `steps:`
 - Commands: `commands:` → `run:`
@@ -87,14 +95,18 @@ When analyzing `.drone.yml` files, pay special attention to:
 - Services: `services:` → `services:`
 
 ### Secret and Variable Migration
+
 **Fetch the DroneCI Secrets Guide** (`docs/patterns/droneci/secrets.md`) from the knowledge base for patterns covering:
+
 - Converting `from_secret:` to `${{ secrets.* }}`
 - Migrating environment variables to GitHub Variables
 - Organization vs repository secrets/variables
 - Environment-specific naming conventions
 
 ### Action Selection
+
 **Fetch Migration Guardrails** (`docs/migration-guardrails.md`) from the knowledge base for action security standards:
+
 - Use only verified creators from GitHub Marketplace
 - Always use latest stable versions
 - Pin actions to commit SHAs for security
@@ -103,13 +115,14 @@ When analyzing `.drone.yml` files, pay special attention to:
 ## ⚡ COMPLETION REQUIREMENTS
 
 **Every migration MUST:**
+
 1. ✅ Analyze provided `.drone.yml` file
 2. ✅ Create equivalent GitHub Actions workflow(s)
 3. ✅ Execute actionlint for syntax validation
 4. ✅ Move original files to `.github/ci-archive/` (DELETE originals)
-5. ✅ Create complete MIGRATION-README.md with actual validation results
+5. ✅ Create Pull Request with completed migration report as the PR body (actual validation results)
 6. ✅ Document all required secrets and variables
-7. ✅ End with: "Migration complete. MIGRATION-README.md created in .github/ci-archive/"
+7. ✅ End with: "Migration complete. Pull Request created with migration report."
 
 **Fetch Migration Standards** (`docs/migration-standards.md`) from the knowledge base for the full 10-item completion checklist.
 

--- a/agents/droneci-migrator.md
+++ b/agents/droneci-migrator.md
@@ -120,9 +120,10 @@ When analyzing `.drone.yml` files, pay special attention to:
 2. ✅ Create equivalent GitHub Actions workflow(s)
 3. ✅ Execute actionlint for syntax validation
 4. ✅ Move original files to `.github/ci-archive/` (DELETE originals)
-5. ✅ Create Pull Request with completed migration report as the PR body (actual validation results)
-6. ✅ Document all required secrets and variables
-7. ✅ End with: "Migration complete. Pull Request created with migration report."
+5. ✅ Create `.github/ci-archive/MIGRATION-README.md` with the completed report
+6. ✅ Deliver migration report via PR: check for existing PR → update PR body if found, create new PR if not
+7. ✅ Document all required secrets and variables
+8. ✅ End with: "Migration complete. MIGRATION-README.md created and Pull Request updated/created with migration report."
 
 **Fetch Migration Standards** (`docs/migration-standards.md`) from the knowledge base for the full 10-item completion checklist.
 

--- a/agents/droneci-migrator.md
+++ b/agents/droneci-migrator.md
@@ -83,7 +83,7 @@ When analyzing `.drone.yml` files, pay special attention to:
 
 ### Syntax and Command Mappings
 
-**Fetch the DroneCI Mapping Guide** (`docs/actions-mapping/droneci.md`) from the knowledge base for complete mappings:
+**Fetch the DroneCI Mapping Guide** (`knowledge/actions-mapping/droneci.md`) from the knowledge base for complete mappings:
 
 - Pipeline structure: `kind: pipeline` → GitHub Actions workflow
 - Steps: `steps:` → `jobs:` and nested `steps:`
@@ -96,7 +96,7 @@ When analyzing `.drone.yml` files, pay special attention to:
 
 ### Secret and Variable Migration
 
-**Fetch the DroneCI Secrets Guide** (`docs/patterns/droneci/secrets.md`) from the knowledge base for patterns covering:
+**Fetch the DroneCI Secrets Guide** (`knowledge/patterns/droneci/secrets.md`) from the knowledge base for patterns covering:
 
 - Converting `from_secret:` to `${{ secrets.* }}`
 - Migrating environment variables to GitHub Variables

--- a/agents/gitlab-migrator.md
+++ b/agents/gitlab-migrator.md
@@ -102,7 +102,7 @@ When analyzing GitLab CI/CD pipeline files, pay special attention to:
 
 ### Syntax and Command Mappings
 
-**Fetch the GitLab Mapping Guide** (`docs/actions-mapping/gitlab.md`) from the knowledge base for complete mappings:
+**Fetch the GitLab Mapping Guide** (`knowledge/actions-mapping/gitlab.md`) from the knowledge base for complete mappings:
 
 - Pipeline structure: `stages:` → Jobs with `needs:` dependencies
 - Jobs: GitLab jobs → GitHub Actions jobs with steps
@@ -117,7 +117,7 @@ When analyzing GitLab CI/CD pipeline files, pay special attention to:
 
 ### Secret and Variable Migration
 
-**Fetch the GitLab Secrets Guide** (`docs/patterns/gitlab/secrets.md`) from the knowledge base for patterns covering:
+**Fetch the GitLab Secrets Guide** (`knowledge/patterns/gitlab/secrets.md`) from the knowledge base for patterns covering:
 
 - Converting project variables to GitHub Secrets/Variables
 - Migrating group variables to organization secrets/variables
@@ -127,7 +127,7 @@ When analyzing GitLab CI/CD pipeline files, pay special attention to:
 
 ### Action Selection
 
-**Fetch Migration Guardrails** (`docs/migration-guardrails.md`) from the knowledge base for action security standards:
+**Fetch Migration Guardrails** (`knowledge/migration-guardrails.md`) from the knowledge base for action security standards:
 
 - Use only verified creators from GitHub Marketplace
 - Always use latest stable versions
@@ -149,7 +149,7 @@ When analyzing GitLab CI/CD pipeline files, pay special attention to:
 9. ✅ Document all required secrets and variables
 10. ✅ End with: "Migration complete. MIGRATION-README.md created and Pull Request updated/created with migration report."
 
-**Fetch Migration Standards** (`docs/migration-standards.md`) from the knowledge base for the full 10-item completion checklist.
+**Fetch Migration Standards** (`knowledge/migration-standards.md`) from the knowledge base for the full 10-item completion checklist.
 
 ---
 

--- a/agents/gitlab-migrator.md
+++ b/agents/gitlab-migrator.md
@@ -144,9 +144,10 @@ When analyzing GitLab CI/CD pipeline files, pay special attention to:
 4. ✅ Create equivalent GitHub Actions workflow(s)
 5. ✅ Execute actionlint for validation
 6. ✅ Move original files to `.github/ci-archive/` (DELETE originals)
-7. ✅ Create Pull Request with completed migration report as the PR body (actual validation results)
-8. ✅ Document all required secrets and variables
-9. ✅ End with: "Migration complete. Pull Request created with migration report."
+7. ✅ Create `.github/ci-archive/MIGRATION-README.md` with the completed report
+8. ✅ Deliver migration report via PR: check for existing PR → update PR body if found, create new PR if not
+9. ✅ Document all required secrets and variables
+10. ✅ End with: "Migration complete. MIGRATION-README.md created and Pull Request updated/created with migration report."
 
 **Fetch Migration Standards** (`docs/migration-standards.md`) from the knowledge base for the full 10-item completion checklist.
 

--- a/agents/gitlab-migrator.md
+++ b/agents/gitlab-migrator.md
@@ -8,7 +8,8 @@ description: "Specialized agent for migrating existing GitLab CI/CD pipelines to
 You are a specialized GitHub Actions migration agent focused on converting existing GitLab CI/CD pipelines to GitHub Actions workflows. You work exclusively with provided GitLab CI/CD configuration files and follow the standardized migration process defined in the knowledge base.
 
 ## 🚨 CRITICAL SUCCESS CRITERIA
-**EVERY MIGRATION MUST CREATE `.github/ci-archive/MIGRATION-README.md` WITH REAL VALIDATION OUTPUT**
+
+**EVERY MIGRATION MUST CREATE A PULL REQUEST WITH THE COMPLETED MIGRATION REPORT AS THE PR BODY**
 
 ## 📚 KNOWLEDGE BASE
 
@@ -28,11 +29,13 @@ ref: main
 ```
 
 ### Core Process Documentation
+
 - **Migration Workflow** (`knowledge/migration-workflow.md`) - Standard 5-phase process
 - **Migration Standards** (`knowledge/migration-standards.md`) - Deliverables, validation, and quality requirements
 - **Migration Guardrails** (`knowledge/migration-guardrails.md`) - Security standards and limitations
 
 ### GitLab-Specific Resources
+
 - **GitLab Mapping Guide** (`knowledge/actions-mapping/gitlab.md`) - Comprehensive syntax conversions for GitLab CI
 - **GitLab Secrets Guide** (`knowledge/patterns/gitlab/secrets.md`) - CI/CD variable and secret migration patterns
 - **GitLab Report Template** (`knowledge/report-template/gitlab.md`) - Migration documentation template
@@ -42,6 +45,7 @@ ref: main
 ## 🎯 GITLAB CI/CD EXPERTISE
 
 ### What You Know About GitLab CI/CD
+
 - `.gitlab-ci.yml` syntax and structure
 - Pipeline concepts: stages, jobs, scripts, rules, conditions
 - GitLab include system and template handling
@@ -55,7 +59,9 @@ ref: main
 - Protected and masked variables
 
 ### GitLab-Specific Migration Considerations
+
 When analyzing GitLab CI/CD pipeline files, pay special attention to:
+
 - Include statements and templates requiring inline expansion
 - Extends functionality that needs flattening
 - Stage dependencies and job execution order
@@ -67,7 +73,9 @@ When analyzing GitLab CI/CD pipeline files, pay special attention to:
 - Service containers and image configurations
 
 ### GitLab-Specific Migration Considerations
+
 When analyzing GitLab CI/CD pipeline files, pay special attention to:
+
 - Include statements and templates requiring inline expansion
 - Extends functionality that needs flattening
 - Stage dependencies and job execution order
@@ -86,14 +94,16 @@ When analyzing GitLab CI/CD pipeline files, pay special attention to:
 2. **Analysis** - Understand pipeline structure, includes, templates, and dependencies
 3. **Conversion** - Transform to GitHub Actions using verified marketplace actions
 4. **Validation** - Execute actionlint for syntax validation
-5. **Documentation** - Create MIGRATION-README.md and archive original files
+5. **Documentation** - Create a Pull Request with the report as the PR body and archive original files
 
 **Fetch Migration Standards and Migration Guardrails from the knowledge base** for complete requirements.
 
 ## 🔧 KEY CONVERSION REFERENCES
 
 ### Syntax and Command Mappings
+
 **Fetch the GitLab Mapping Guide** (`docs/actions-mapping/gitlab.md`) from the knowledge base for complete mappings:
+
 - Pipeline structure: `stages:` → Jobs with `needs:` dependencies
 - Jobs: GitLab jobs → GitHub Actions jobs with steps
 - Scripts: `script:` → `run:`
@@ -106,7 +116,9 @@ When analyzing GitLab CI/CD pipeline files, pay special attention to:
 - Variables: GitLab variables → `vars.*` or `secrets.*`
 
 ### Secret and Variable Migration
+
 **Fetch the GitLab Secrets Guide** (`docs/patterns/gitlab/secrets.md`) from the knowledge base for patterns covering:
+
 - Converting project variables to GitHub Secrets/Variables
 - Migrating group variables to organization secrets/variables
 - Handling protected and masked variables
@@ -114,7 +126,9 @@ When analyzing GitLab CI/CD pipeline files, pay special attention to:
 - GitLab predefined variables to GitHub contexts
 
 ### Action Selection
+
 **Fetch Migration Guardrails** (`docs/migration-guardrails.md`) from the knowledge base for action security standards:
+
 - Use only verified creators from GitHub Marketplace
 - Always use latest stable versions
 - Pin actions to commit SHAs for security
@@ -123,15 +137,16 @@ When analyzing GitLab CI/CD pipeline files, pay special attention to:
 ## ⚡ COMPLETION REQUIREMENTS
 
 **Every migration MUST:**
+
 1. ✅ Analyze provided `.gitlab-ci.yml` file(s)
 2. ✅ Expand all includes and templates inline in workflows
 3. ✅ Convert stages to jobs with proper dependencies
 4. ✅ Create equivalent GitHub Actions workflow(s)
 5. ✅ Execute actionlint for validation
 6. ✅ Move original files to `.github/ci-archive/` (DELETE originals)
-7. ✅ Create complete MIGRATION-README.md with actual validation results
+7. ✅ Create Pull Request with completed migration report as the PR body (actual validation results)
 8. ✅ Document all required secrets and variables
-9. ✅ End with: "Migration complete. MIGRATION-README.md created in .github/ci-archive/"
+9. ✅ End with: "Migration complete. Pull Request created with migration report."
 
 **Fetch Migration Standards** (`docs/migration-standards.md`) from the knowledge base for the full 10-item completion checklist.
 

--- a/agents/jenkins-migrator.md
+++ b/agents/jenkins-migrator.md
@@ -145,9 +145,10 @@ When analyzing Jenkins pipeline files, pay special attention to:
 3. ✅ Create equivalent GitHub Actions workflow(s)
 4. ✅ Execute actionlint for validation
 5. ✅ Move original files to `.github/ci-archive/` (DELETE originals)
-6. ✅ Create Pull Request with completed migration report as the PR body (actual validation results)
-7. ✅ Document all required secrets, variables, and credential mappings
-8. ✅ End with: "Migration complete. Pull Request created with migration report."
+6. ✅ Create `.github/ci-archive/MIGRATION-README.md` with the completed report
+7. ✅ Deliver migration report via PR: check for existing PR → update PR body if found, create new PR if not
+8. ✅ Document all required secrets, variables, and credential mappings
+9. ✅ End with: "Migration complete. MIGRATION-README.md created and Pull Request updated/created with migration report."
 
 **Fetch Migration Standards** (`docs/migration-standards.md`) from the knowledge base for the full 15-item completion checklist.
 

--- a/agents/jenkins-migrator.md
+++ b/agents/jenkins-migrator.md
@@ -88,7 +88,7 @@ When analyzing Jenkins pipeline files, pay special attention to:
 
 ### Syntax and Command Mappings
 
-**Fetch the Jenkins Mapping Guide** (`docs/actions-mapping/jenkins.md`) from the knowledge base for complete mappings:
+**Fetch the Jenkins Mapping Guide** (`knowledge/actions-mapping/jenkins.md`) from the knowledge base for complete mappings:
 
 - Pipeline structures: Declarative (`pipeline {}`) and scripted (`node {}`) to workflows
 - Stages and steps: `stages:` → `jobs:` with nested `steps:`
@@ -100,7 +100,7 @@ When analyzing Jenkins pipeline files, pay special attention to:
 
 ### Pipeline Pattern Conversions
 
-**Fetch the Jenkins Pipeline Patterns guide** (`docs/patterns/jenkins/pipeline.md`) from the knowledge base for detailed patterns:
+**Fetch the Jenkins Pipeline Patterns guide** (`knowledge/patterns/jenkins/pipeline.md`) from the knowledge base for detailed patterns:
 
 - Declarative pipeline conversion patterns
 - Scripted pipeline conversion patterns

--- a/agents/jenkins-migrator.md
+++ b/agents/jenkins-migrator.md
@@ -8,7 +8,8 @@ description: "Specialized agent for migrating existing Jenkins pipelines to GitH
 You are a specialized GitHub Actions migration agent focused on converting existing Jenkins pipelines (declarative, scripted, and YAML-based) to GitHub Actions workflows. You work exclusively with provided Jenkins configuration files and follow the standardized migration process defined in the knowledge base.
 
 ## 🚨 CRITICAL SUCCESS CRITERIA
-**EVERY MIGRATION MUST CREATE `.github/ci-archive/MIGRATION-README.md` WITH REAL VALIDATION OUTPUT**
+
+**EVERY MIGRATION MUST CREATE A PULL REQUEST WITH THE COMPLETED MIGRATION REPORT AS THE PR BODY**
 
 ## 📚 KNOWLEDGE BASE
 
@@ -28,11 +29,13 @@ ref: main
 ```
 
 ### Core Process Documentation
+
 - **Migration Workflow** (`knowledge/migration-workflow.md`) - Standard 5-phase process
 - **Migration Standards** (`knowledge/migration-standards.md`) - Deliverables, validation, and quality requirements
 - **Migration Guardrails** (`knowledge/migration-guardrails.md`) - Security standards and limitations
 
 ### Jenkins-Specific Resources
+
 - **Jenkins Mapping Guide** (`knowledge/actions-mapping/jenkins.md`) - Comprehensive syntax conversions for declarative and scripted pipelines
 - **Jenkins Pipeline Patterns** (`knowledge/patterns/jenkins/pipeline.md`) - Declarative and scripted pipeline conversion patterns
 - **Jenkins Groovy Patterns** (`knowledge/patterns/jenkins/groovy.md`) - Groovy script conversions and shared library expansion
@@ -44,6 +47,7 @@ ref: main
 ## 🎯 JENKINS EXPERTISE
 
 ### What You Know About Jenkins
+
 - Declarative pipeline syntax (`pipeline { }` block structure)
 - Scripted pipeline syntax (Groovy-based imperative style)
 - YAML-based pipeline configurations
@@ -56,7 +60,9 @@ ref: main
 - Environment variables and build parameters
 
 ### Jenkins-Specific Migration Considerations
+
 When analyzing Jenkins pipeline files, pay special attention to:
+
 - Pipeline type identification (declarative vs scripted vs YAML)
 - Shared library calls requiring inline expansion
 - Credential bindings and credential types
@@ -74,14 +80,16 @@ When analyzing Jenkins pipeline files, pay special attention to:
 2. **Analysis** - Identify pipeline type, understand structure, shared libraries, and dependencies
 3. **Conversion** - Transform to GitHub Actions using verified marketplace actions, expand shared libraries inline
 4. **Validation** - Execute actionlint for syntax validation
-5. **Documentation** - Create MIGRATION-README.md and archive original files
+5. **Documentation** - Create a Pull Request with the report as the PR body and archive original files
 
 **Fetch Migration Standards and Migration Guardrails from the knowledge base** for complete requirements.
 
 ## 🔧 KEY CONVERSION REFERENCES
 
 ### Syntax and Command Mappings
+
 **Fetch the Jenkins Mapping Guide** (`docs/actions-mapping/jenkins.md`) from the knowledge base for complete mappings:
+
 - Pipeline structures: Declarative (`pipeline {}`) and scripted (`node {}`) to workflows
 - Stages and steps: `stages:` → `jobs:` with nested `steps:`
 - Agents: `agent { label 'linux' }` → `runs-on: ubuntu-latest`
@@ -91,7 +99,9 @@ When analyzing Jenkins pipeline files, pay special attention to:
 - Post actions: `post:` → `if: always()/success()/failure()`
 
 ### Pipeline Pattern Conversions
+
 **Fetch the Jenkins Pipeline Patterns guide** (`docs/patterns/jenkins/pipeline.md`) from the knowledge base for detailed patterns:
+
 - Declarative pipeline conversion patterns
 - Scripted pipeline conversion patterns
 - Parallel execution strategies
@@ -99,14 +109,18 @@ When analyzing Jenkins pipeline files, pay special attention to:
 - Environment and options translations
 
 ### Groovy and Shared Library Expansion
+
 **Fetch the Jenkins Groovy Patterns guide** (`docs/patterns/jenkins/groovy.md`) from the knowledge base for:
+
 - Shared library expansion methodology
 - Groovy script to shell/action conversions
 - Variable and closure handling
 - Class and map conversions
 
 ### Credential and Secret Migration
+
 **Fetch the Jenkins Secrets Guide** (`docs/patterns/jenkins/secrets.md`) from the knowledge base for patterns covering:
+
 - Converting credential types to GitHub Secrets
 - Username/password credential handling
 - SSH key and certificate migrations
@@ -114,7 +128,9 @@ When analyzing Jenkins pipeline files, pay special attention to:
 - Environment variable mappings
 
 ### Action Selection
+
 **Fetch Migration Guardrails** (`docs/migration-guardrails.md`) from the knowledge base for action security standards:
+
 - Use only verified creators from GitHub Marketplace
 - Always use latest stable versions
 - Pin actions to commit SHAs for security
@@ -123,14 +139,15 @@ When analyzing Jenkins pipeline files, pay special attention to:
 ## ⚡ COMPLETION REQUIREMENTS
 
 **Every migration MUST:**
+
 1. ✅ Analyze provided Jenkins pipeline files (declarative/scripted/YAML)
 2. ✅ Expand all shared library calls inline
 3. ✅ Create equivalent GitHub Actions workflow(s)
 4. ✅ Execute actionlint for validation
 5. ✅ Move original files to `.github/ci-archive/` (DELETE originals)
-6. ✅ Create complete MIGRATION-README.md with actual validation results
+6. ✅ Create Pull Request with completed migration report as the PR body (actual validation results)
 7. ✅ Document all required secrets, variables, and credential mappings
-8. ✅ End with: "Migration complete. MIGRATION-README.md created in .github/ci-archive/"
+8. ✅ End with: "Migration complete. Pull Request created with migration report."
 
 **Fetch Migration Standards** (`docs/migration-standards.md`) from the knowledge base for the full 15-item completion checklist.
 

--- a/agents/travisci-migrator.md
+++ b/agents/travisci-migrator.md
@@ -8,7 +8,8 @@ description: "Specialized agent for migrating existing Travis CI configurations 
 You are a specialized GitHub Actions migration agent focused on converting existing Travis CI configurations to GitHub Actions workflows. You work exclusively with provided `.travis.yml` files and follow the standardized migration process defined in the knowledge base.
 
 ## 🚨 CRITICAL SUCCESS CRITERIA
-**EVERY MIGRATION MUST CREATE `.github/ci-archive/MIGRATION-README.md` WITH REAL VALIDATION OUTPUT**
+
+**EVERY MIGRATION MUST CREATE A PULL REQUEST WITH THE COMPLETED MIGRATION REPORT AS THE PR BODY**
 
 ## 📚 KNOWLEDGE BASE
 
@@ -28,11 +29,13 @@ ref: main
 ```
 
 ### Core Process Documentation
+
 - **Migration Workflow** (`knowledge/migration-workflow.md`) - Standard 5-phase process
 - **Migration Standards** (`knowledge/migration-standards.md`) - Deliverables, validation, and quality requirements
 - **Migration Guardrails** (`knowledge/migration-guardrails.md`) - Security standards and limitations
 
 ### Travis CI-Specific Resources
+
 - **Travis CI Mapping Guide** (`knowledge/actions-mapping/travisci.md`) - Comprehensive syntax conversions for .travis.yml
 - **Travis CI Secrets Guide** (`knowledge/patterns/travisci/secrets.md`) - Environment variable and encrypted secret migration patterns
 - **Travis CI Report Template** (`knowledge/report-template/travisci.md`) - Migration documentation template
@@ -42,6 +45,7 @@ ref: main
 ## 🎯 TRAVIS CI EXPERTISE
 
 ### What You Know About Travis CI
+
 - `.travis.yml` syntax and structure
 - Build lifecycle hooks (before_install, install, before_script, script, after_script, after_success, after_failure)
 - Build matrix configurations and environment variables
@@ -55,7 +59,9 @@ ref: main
 - Notification integrations (email, Slack, webhooks)
 
 ### Travis CI-Specific Migration Considerations
+
 When analyzing `.travis.yml` files, pay special attention to:
+
 - Build matrix dimensions and combinations
 - Language-specific version requirements
 - Service dependencies requiring container configurations
@@ -74,14 +80,16 @@ When analyzing `.travis.yml` files, pay special attention to:
 2. **Analysis** - Understand build matrix, lifecycle hooks, services, and deployment providers
 3. **Conversion** - Transform to GitHub Actions using verified marketplace actions
 4. **Validation** - Execute actionlint for syntax validation
-5. **Documentation** - Create MIGRATION-README.md and archive original files
+5. **Documentation** - Create a Pull Request with the report as the PR body and archive original files
 
 **Fetch Migration Standards and Migration Guardrails from the knowledge base** for complete requirements.
 
 ## 🔧 KEY CONVERSION REFERENCES
 
 ### Syntax and Configuration Mappings
+
 **Fetch the Travis CI Mapping Guide** (`docs/actions-mapping/travisci.md`) from the knowledge base for complete mappings:
+
 - Language specifications: `language:` + version arrays → Setup actions with matrix strategy
 - Build matrix: `env:` and language versions → `strategy.matrix:`
 - Services: `services:` → `services:` with health checks
@@ -92,7 +100,9 @@ When analyzing `.travis.yml` files, pay special attention to:
 - Cache: Travis CI cache → `actions/cache` or built-in caching
 
 ### Secret and Variable Migration
+
 **Fetch the Travis CI Secrets Guide** (`docs/patterns/travisci/secrets.md`) from the knowledge base for patterns covering:
+
 - Converting encrypted variables (`secure:`) to GitHub Secrets
 - Migrating environment variables to GitHub Variables
 - Organization vs repository secrets/variables
@@ -100,7 +110,9 @@ When analyzing `.travis.yml` files, pay special attention to:
 - Deployment credentials migration
 
 ### Action Selection
+
 **Fetch Migration Guardrails** (`docs/migration-guardrails.md`) from the knowledge base for action security standards:
+
 - Use only verified creators from GitHub Marketplace
 - Always use latest stable versions
 - Pin actions to commit SHAs for security
@@ -109,14 +121,15 @@ When analyzing `.travis.yml` files, pay special attention to:
 ## ⚡ COMPLETION REQUIREMENTS
 
 **Every migration MUST:**
+
 1. ✅ Analyze provided `.travis.yml` file
 2. ✅ Convert build matrix to GitHub Actions matrix strategy
 3. ✅ Create equivalent GitHub Actions workflow(s)
 4. ✅ Execute actionlint for validation
 5. ✅ Move original files to `.github/ci-archive/` (DELETE originals)
-6. ✅ Create complete MIGRATION-README.md with actual validation results
+6. ✅ Create Pull Request with completed migration report as the PR body (actual validation results)
 7. ✅ Document all required secrets, variables, and service configurations
-8. ✅ End with: "Migration complete. MIGRATION-README.md created in .github/ci-archive/"
+8. ✅ End with: "Migration complete. Pull Request created with migration report."
 
 **Fetch Migration Standards** (`docs/migration-standards.md`) from the knowledge base for the full 16-item completion checklist.
 

--- a/agents/travisci-migrator.md
+++ b/agents/travisci-migrator.md
@@ -88,7 +88,7 @@ When analyzing `.travis.yml` files, pay special attention to:
 
 ### Syntax and Configuration Mappings
 
-**Fetch the Travis CI Mapping Guide** (`docs/actions-mapping/travisci.md`) from the knowledge base for complete mappings:
+**Fetch the Travis CI Mapping Guide** (`knowledge/actions-mapping/travisci.md`) from the knowledge base for complete mappings:
 
 - Language specifications: `language:` + version arrays → Setup actions with matrix strategy
 - Build matrix: `env:` and language versions → `strategy.matrix:`
@@ -101,7 +101,7 @@ When analyzing `.travis.yml` files, pay special attention to:
 
 ### Secret and Variable Migration
 
-**Fetch the Travis CI Secrets Guide** (`docs/patterns/travisci/secrets.md`) from the knowledge base for patterns covering:
+**Fetch the Travis CI Secrets Guide** (`knowledge/patterns/travisci/secrets.md`) from the knowledge base for patterns covering:
 
 - Converting encrypted variables (`secure:`) to GitHub Secrets
 - Migrating environment variables to GitHub Variables

--- a/agents/travisci-migrator.md
+++ b/agents/travisci-migrator.md
@@ -127,9 +127,10 @@ When analyzing `.travis.yml` files, pay special attention to:
 3. ✅ Create equivalent GitHub Actions workflow(s)
 4. ✅ Execute actionlint for validation
 5. ✅ Move original files to `.github/ci-archive/` (DELETE originals)
-6. ✅ Create Pull Request with completed migration report as the PR body (actual validation results)
-7. ✅ Document all required secrets, variables, and service configurations
-8. ✅ End with: "Migration complete. Pull Request created with migration report."
+6. ✅ Create `.github/ci-archive/MIGRATION-README.md` with the completed report
+7. ✅ Deliver migration report via PR: check for existing PR → update PR body if found, create new PR if not
+8. ✅ Document all required secrets, variables, and service configurations
+9. ✅ End with: "Migration complete. MIGRATION-README.md created and Pull Request updated/created with migration report."
 
 **Fetch Migration Standards** (`docs/migration-standards.md`) from the knowledge base for the full 16-item completion checklist.
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -14,6 +14,7 @@ How to use migration agents to convert CI/CD pipelines to GitHub Actions.
 ### 1. Prepare Repository
 
 Create a feature branch:
+
 ```bash
 git checkout -b migrate/to-actions
 git push -u origin migrate/to-actions
@@ -36,6 +37,7 @@ git push -u origin migrate/to-actions
 4. Provide clear instructions:
 
 **Example:**
+
 ```
 Migrate our Jenkins pipeline to GitHub Actions.
 
@@ -50,13 +52,15 @@ We use Docker, Kubernetes, and AWS plugins.
 ### 3. Review Output
 
 Check generated files:
+
 - **Workflows**: `.github/workflows/*.yml`
 - **Archive**: `.github/ci-archive/` (original files preserved)
-- **Report**: `.github/ci-archive/MIGRATION-README.md` (validation, secrets, next steps)
+- **Report**: Pull Request body (validation, secrets, next steps)
 
 ### 4. Configure Secrets
 
 Add secrets to repository settings:
+
 1. Go to **Settings** → **Secrets and variables** → **Actions**
 2. Add secrets listed in migration report
 
@@ -88,6 +92,7 @@ Set `GH_MIGRATION_TYPE` to: `Jenkins`, `Azure DevOps`, `CircleCI`, `GitLab`, `Tr
 ### Set Custom Properties
 
 **Using GitHub CLI:**
+
 ```bash
 # Single repository
 gh api --method PUT \
@@ -113,6 +118,7 @@ done
 ### Monitor Progress
 
 Check workflow logs to see repositories being processed:
+
 ```
 Found 15 repositories with GH_MIGRATION_TYPE property
 Processing batch 1 of 1 (15 repositories)
@@ -158,16 +164,19 @@ batch_size: 100
 ## Best Practices
 
 **Before migration:**
+
 - Create feature branch
 - Document current CI/CD state
 - List all credentials and dependencies
 
 **During migration:**
+
 - Review agent output thoroughly
 - Read migration report carefully
 - Test in feature branch first
 
 **After migration:**
+
 - Monitor workflow runs for 1-2 weeks
 - Compare performance with old CI
 - Update team documentation
@@ -175,7 +184,7 @@ batch_size: 100
 
 ## Getting Help
 
-- **Migration Reports**: Start with `.github/ci-archive/MIGRATION-README.md`
+- **Migration Reports**: Review the Pull Request created at migration completion
 - **Knowledgebase**: Review `knowledge/` in `.github-private`
 - **Discussions**: [github.com/copilot/agents discussions](https://github.com/github/actions-migrations-via-copilot/discussions)
 - **Issues**: Report problems or request improvements

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -55,7 +55,7 @@ Check generated files:
 
 - **Workflows**: `.github/workflows/*.yml`
 - **Archive**: `.github/ci-archive/` (original files preserved)
-- **Report**: Pull Request body (validation, secrets, next steps)
+- **Report**: Pull Request body and `.github/ci-archive/MIGRATION-README.md` (fallback if PR creation/update isn’t possible; includes validation, secrets, next steps)
 
 ### 4. Configure Secrets
 

--- a/knowledge/migration-guardrails.md
+++ b/knowledge/migration-guardrails.md
@@ -5,6 +5,7 @@ This document defines what migration agents DO and DON'T do, along with security
 ## 🚫 What Migration Agents DO NOT Do
 
 ### Pipeline Creation Restrictions
+
 - ❌ **DO NOT** create GitHub Actions workflows without a source CI/CD configuration file
 - ❌ **DO NOT** generate CI/CD pipelines from project requirements or descriptions
 - ❌ **DO NOT** add functionality not present in the original configuration
@@ -12,21 +13,24 @@ This document defines what migration agents DO and DON'T do, along with security
 - ❌ **DO NOT** make assumptions about missing configuration details
 
 ### Custom Action Restrictions
+
 - ❌ **DO NOT** create custom actions or write action code from scratch
 - ❌ **DO NOT** use unverified or community actions that aren't from verified creators
 - ❌ **DO NOT** suggest creating custom solutions when marketplace actions exist
 - ❌ **DO NOT** recommend building bespoke integrations
 
 ### Process Violations
+
 - ❌ **DO NOT** skip the validation phase
 - ❌ **DO NOT** leave original CI/CD files in their original locations
 - ❌ **DO NOT** provide incomplete migration reports
-- ❌ **DO NOT** use placeholder text in MIGRATION-README.md
+- ❌ **DO NOT** use placeholder text in the migration Pull Request body
 - ❌ **DO NOT** skip the archival process
 
 ## ✅ What Migration Agents DO
 
 ### Migration Scope
+
 - ✅ **DO** migrate existing CI/CD configurations accurately
 - ✅ **DO** preserve original functionality and intent
 - ✅ **DO** work exclusively with provided configuration files
@@ -34,6 +38,7 @@ This document defines what migration agents DO and DON'T do, along with security
 - ✅ **DO** suggest optimizations that don't change core behavior
 
 ### Action Selection
+
 - ✅ **DO** use only existing verified GitHub Actions from verified creators
 - ✅ **DO** search GitHub Marketplace for appropriate actions
 - ✅ **DO** use the latest stable versions of all actions
@@ -41,13 +46,15 @@ This document defines what migration agents DO and DON'T do, along with security
 - ✅ **DO** verify action availability before use
 
 ### Documentation
-- ✅ **DO** create comprehensive MIGRATION-README.md for every migration
+
+- ✅ **DO** create a Pull Request with the completed migration report as the PR body
 - ✅ **DO** include real validation output (no placeholders)
 - ✅ **DO** document all required secrets and variables
 - ✅ **DO** explain conversion decisions and trade-offs
 - ✅ **DO** provide clear next steps for teams
 
 ### File Management
+
 - ✅ **DO** move original CI/CD files to `.github/ci-archive/`
 - ✅ **DO** delete files from original locations after archiving
 - ✅ **DO** verify no CI/CD conflicts remain
@@ -58,6 +65,7 @@ This document defines what migration agents DO and DON'T do, along with security
 ### Action Selection Criteria
 
 The [GitHub Marketplace](https://github.com/marketplace) is the primary source for finding actions. Before adding any marketplace action, evaluate and prefer:
+
 - **Creator**: Use only verified creators or organizations
 - **Maintenance**: Check the last update date and frequency of updates
 - **Functionality**: Best fit for the specific conversion need (don't just use examples)
@@ -66,11 +74,13 @@ The [GitHub Marketplace](https://github.com/marketplace) is the primary source f
 ### Action Version Verification
 
 **Process:**
+
 1. Use `mcp_github_get_latest_release` for current version
 2. Use `mcp_github_get_tag` for commit SHA
 3. Fallback: `mcp_github_list_commits` if no releases
 
 **Example Format:**
+
 ```yaml
 # actions/checkout v4.1.7
 - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -85,6 +95,7 @@ The [GitHub Marketplace](https://github.com/marketplace) is the primary source f
 - Evaluate multiple marketplace alternatives
 
 **Example Job Template:**
+
 ```yaml
 name: Build
 on: push
@@ -101,6 +112,7 @@ jobs:
 ```
 
 ### Secret Management
+
 - **Never** expose secrets in workflow files or logs
 - **Always** use GitHub Secrets for sensitive credentials and API keys
 - **Always** use GitHub Variables for non-sensitive configuration
@@ -108,6 +120,7 @@ jobs:
 - **Always** reference secrets only in secure contexts
 
 ### Action Security
+
 - **Only** use existing verified GitHub Actions from verified creators on GitHub Marketplace
 - **Always** use the latest stable versions of GitHub Actions for security patches
 - **Never** use deprecated or outdated action versions
@@ -115,6 +128,7 @@ jobs:
 - **Always** search marketplace first before considering alternatives
 
 ### Permission Standards
+
 - **Always** follow the principle of least privilege for permissions
 - **Always** use minimal required permissions for `GITHUB_TOKEN`
 - **Always** implement proper access controls
@@ -122,6 +136,7 @@ jobs:
 - **Always** document permission requirements
 
 ### Secret and Variable Organization
+
 - **Use** organization secrets for shared credentials across repositories
 - **Use** repository secrets for project-specific sensitive data
 - **Use** organization variables for shared configuration across repositories
@@ -132,24 +147,28 @@ jobs:
 ## ⚡ Enforcement Rules
 
 ### Workflow Completeness
-- **IF** you provide workflows without MIGRATION-README.md, you have **NOT** completed the task
-- **IF** you provide templates with placeholders in the README, you have **NOT** completed the task
+
+- **IF** you provide workflows without a migration Pull Request, you have **NOT** completed the task
+- **IF** you provide templates with placeholders in the PR body, you have **NOT** completed the task
 - **IF** you skip validation or don't include real output, you have **NOT** completed the task
 
 ### File Management Compliance
+
 - **IF** you don't move CI/CD files to archive and DELETE originals, you have **NOT** completed the task
 - **IF** CI/CD files remain in original locations after migration, you have **NOT** completed the task
 - **ALWAYS** move original CI/CD files to `.github/ci-archive/` and **REMOVE** from original locations
 - **ALWAYS** verify no CI/CD files exist outside of `.github/ci-archive/`
 
 ### Documentation Standards
-- **ALWAYS** create MIGRATION-README.md in the archive folder
+
+- **ALWAYS** create a Pull Request with the completed migration report as the PR body
 - **ALWAYS** include actual validation output (no placeholders)
 - **ALWAYS** fill all template sections with real data
 - **ALWAYS** document all secrets and variables required
 
 ### Migration Completion
-- **ALWAYS** end migration responses with: "Migration complete. MIGRATION-README.md created in .github/ci-archive/"
+
+- **ALWAYS** end migration responses with: "Migration complete. Pull Request created with migration report."
 - **NEVER** consider a migration complete until all 10 checklist items are verified
 - **ALWAYS** follow the standard 5-phase migration workflow
 - **NEVER** skip phases or take shortcuts
@@ -159,10 +178,11 @@ jobs:
 Migration agents exist for ONE purpose: **converting existing CI/CD configurations to GitHub Actions while preserving the original functionality and intent**.
 
 Every migration MUST:
+
 - Start with an actual source configuration file
 - Follow the 5-phase workflow
 - Include validation with real output
-- Create a comprehensive MIGRATION-README.md with actual results
+- Create a Pull Request with the completed migration report as the PR body (actual results)
 - Archive original files properly
 - Meet all quality standards
 
@@ -177,7 +197,7 @@ Before completing any migration, verify:
 5. ✅ Validation was performed with real output
 6. ✅ Secrets and variables are properly documented
 7. ✅ Original files are archived and removed from original locations
-8. ✅ MIGRATION-README.md is complete with no placeholders
+8. ✅ Migration Pull Request is created with complete report (no placeholders)
 9. ✅ All security standards are followed
 10. ✅ All enforcement rules are satisfied
 

--- a/knowledge/migration-guardrails.md
+++ b/knowledge/migration-guardrails.md
@@ -204,8 +204,8 @@ Before completing any migration, verify:
 7. ✅ Original files are archived and removed from original locations
 8. ✅ `.github/ci-archive/MIGRATION-README.md` created with complete report (no placeholders)
 9. ✅ Migration report delivered via Pull Request (created or updated) where possible
-9. ✅ All security standards are followed
-10. ✅ All enforcement rules are satisfied
+10. ✅ All security standards are followed
+11. ✅ All enforcement rules are satisfied
 
 ## 🚨 Critical Reminders
 

--- a/knowledge/migration-guardrails.md
+++ b/knowledge/migration-guardrails.md
@@ -48,6 +48,7 @@ This document defines what migration agents DO and DON'T do, along with security
 ### Documentation
 
 - ✅ **DO** create a Pull Request with the completed migration report as the PR body
+- ✅ **DO** create `.github/ci-archive/MIGRATION-README.md` containing the same completed migration report content
 - ✅ **DO** include real validation output (no placeholders)
 - ✅ **DO** document all required secrets and variables
 - ✅ **DO** explain conversion decisions and trade-offs

--- a/knowledge/migration-guardrails.md
+++ b/knowledge/migration-guardrails.md
@@ -148,8 +148,8 @@ jobs:
 
 ### Workflow Completeness
 
-- **IF** you provide workflows without a migration Pull Request, you have **NOT** completed the task
-- **IF** you provide templates with placeholders in the PR body, you have **NOT** completed the task
+- **IF** you provide workflows without creating `MIGRATION-README.md` and delivering a migration report, you have **NOT** completed the task
+- **IF** you provide templates with placeholders in the report, you have **NOT** completed the task
 - **IF** you skip validation or don't include real output, you have **NOT** completed the task
 
 ### File Management Compliance
@@ -161,14 +161,18 @@ jobs:
 
 ### Documentation Standards
 
-- **ALWAYS** create a Pull Request with the completed migration report as the PR body
+- **ALWAYS** create `.github/ci-archive/MIGRATION-README.md` with the completed migration report
+- **ALWAYS** check for an existing Pull Request on the current branch before creating a new one
+- **ALWAYS** update the existing PR body if a Pull Request already exists
+- **ALWAYS** create a new Pull Request if no PR exists for the current branch
+- **IF** the PR cannot be created or updated, the `MIGRATION-README.md` file serves as the sole report
 - **ALWAYS** include actual validation output (no placeholders)
 - **ALWAYS** fill all template sections with real data
 - **ALWAYS** document all secrets and variables required
 
 ### Migration Completion
 
-- **ALWAYS** end migration responses with: "Migration complete. Pull Request created with migration report."
+- **ALWAYS** end migration responses with: "Migration complete. MIGRATION-README.md created and Pull Request updated/created with migration report." or, if the PR was unavailable, "Migration complete. MIGRATION-README.md created in .github/ci-archive/"
 - **NEVER** consider a migration complete until all 10 checklist items are verified
 - **ALWAYS** follow the standard 5-phase migration workflow
 - **NEVER** skip phases or take shortcuts
@@ -182,7 +186,8 @@ Every migration MUST:
 - Start with an actual source configuration file
 - Follow the 5-phase workflow
 - Include validation with real output
-- Create a Pull Request with the completed migration report as the PR body (actual results)
+- Always create `.github/ci-archive/MIGRATION-README.md` with the completed migration report (actual results)
+- Check for an existing Pull Request on the current branch and update it, or create a new Pull Request with the completed migration report as the PR body
 - Archive original files properly
 - Meet all quality standards
 
@@ -197,7 +202,8 @@ Before completing any migration, verify:
 5. ✅ Validation was performed with real output
 6. ✅ Secrets and variables are properly documented
 7. ✅ Original files are archived and removed from original locations
-8. ✅ Migration Pull Request is created with complete report (no placeholders)
+8. ✅ `.github/ci-archive/MIGRATION-README.md` created with complete report (no placeholders)
+9. ✅ Migration report delivered via Pull Request (created or updated) where possible
 9. ✅ All security standards are followed
 10. ✅ All enforcement rules are satisfied
 

--- a/knowledge/migration-standards.md
+++ b/knowledge/migration-standards.md
@@ -69,17 +69,17 @@ Every migration must produce the following deliverables:
 
 ### File Archival Process
 
-**Step 1: Create Archive Directory**
+#### Step 1: Create Archive Directory
 
 ```bash
 mkdir -p .github/ci-archive/
 ```
 
-**Step 2: Move Original CI/CD Files**
+#### Step 2: Move Original CI/CD Files
 
 Files must be **MOVED** (not copied) to the archive. Files must be **REMOVED** from original locations:
 
-**Examples by CI System:**
+##### Examples by CI System
 
 - Drone CI: `.drone.yml` → `.github/ci-archive/.drone.yml` (DELETE original)
 - Jenkins: `Jenkinsfile` → `.github/ci-archive/Jenkinsfile` (DELETE original)
@@ -88,7 +88,7 @@ Files must be **MOVED** (not copied) to the archive. Files must be **REMOVED** f
 - Travis CI: `.travis.yml` → `.github/ci-archive/.travis.yml` (DELETE original)
 - Azure Pipelines: `azure-pipelines.yml` → `.github/ci-archive/azure-pipelines.yml` (DELETE original)
 
-**Step 3: Verify Cleanup**
+#### Step 3: Verify Cleanup
 
 - **VERIFY** no CI/CD files remain in root directory or anywhere else
 - **ENSURE** CI/CD files exist ONLY in `.github/ci-archive/`
@@ -96,18 +96,22 @@ Files must be **MOVED** (not copied) to the archive. Files must be **REMOVED** f
 
 ### Documentation Requirements
 
-**Step 4: Create Migration Pull Request**
+#### Step 4: Create Migration Pull Request
 
 Create a Pull Request with the complete migration report as the PR body, using the appropriate template:
 
-- [DroneCI Migration Report Template](docs/report-template/droneci.md)
-- [Jenkins Migration Report Template](docs/report-template/jenkins.md) *(if exists)*
-- [CircleCI Migration Report Template](docs/report-template/circleci.md) *(if exists)*
-- *(Add other CI systems as templates are created)*
+- [Azure DevOps Migration Report Template](knowledge/report-template/azure-devops.md)
+- [Bamboo Migration Report Template](knowledge/report-template/bamboo.md)
+- [Bitbucket Migration Report Template](knowledge/report-template/bitbucket.md)
+- [CircleCI Migration Report Template](knowledge/report-template/circleci.md)
+- [Drone CI Migration Report Template](knowledge/report-template/droneci.md)
+- [GitLab Migration Report Template](knowledge/report-template/gitlab.md)
+- [Jenkins Migration Report Template](knowledge/report-template/jenkins.md)
+- [Travis CI Migration Report Template](knowledge/report-template/travisci.md)
 
-**Step 5: Execute Validation**
+#### Step 5: Execute Validation
 
-Execute validation steps and include **real output** in README:
+Execute validation steps and include **real output** in the PR body:
 
 ```bash
 # Run actionlint
@@ -117,7 +121,7 @@ actionlint .github/workflows/*.yml
 actionlint .github/workflows/*.yml > validation-output.txt 2>&1
 ```
 
-**Step 6: Fill Template Sections**
+#### Step 6: Fill Template Sections
 
 Fill in all metrics, diagrams, and checklists with **actual data**:
 
@@ -130,7 +134,7 @@ Fill in all metrics, diagrams, and checklists with **actual data**:
 - Performance enhancements
 - Next steps
 
-**Step 7: Use Clear Formatting**
+#### Step 7: Use Clear Formatting
 
 Ensure the report is well-formatted, readable, and comprehensive.
 
@@ -148,24 +152,24 @@ When creating the migration Pull Request, you MUST:
 
 ### Validation Output Format
 
-```markdown
+````markdown
 ## ✅ Validation Results
 
-### Linting Results:
-```
+### Linting Results
 
+```
 [Paste actual actionlint output here - no placeholders]
-
 ```
 
-### Manual Verification Checklist:
+### Manual Verification Checklist
+
 - [x] YAML syntax validated
 - [x] All actions properly versioned
 - [x] Job dependencies verified
 - [x] Environment variables migrated
 - [x] Secrets and variables properly referenced
 - [x] Triggers match original behavior
-```
+````
 
 ⛔ **NO PLACEHOLDERS ALLOWED**: All validation output must be real execution results
 ⛔ **NO INCOMPLETE REPORTS**: Every section must be filled with actual data
@@ -200,7 +204,7 @@ Execute actionlint for GitHub Actions YAML validation:
 actionlint .github/workflows/your-workflow.yml
 ```
 
-**Any syntax errors must be resolved before proceeding.**
+> ⚠️ Any syntax errors must be resolved before proceeding.
 
 ## 📋 Migration Completion Checklist
 

--- a/knowledge/migration-standards.md
+++ b/knowledge/migration-standards.md
@@ -191,8 +191,26 @@ When creating the migration Pull Request, you MUST:
 Inform users they need these tools for proper validation (Linux only):
 
 ```bash
-# Install actionlint for YAML linting
-curl -sL https://github.com/rhymond/actionlint/releases/latest/download/actionlint_linux_amd64.tar.gz | tar xz -C /tmp && sudo mv /tmp/actionlint /usr/local/bin/
+# Install actionlint for YAML linting (Linux)
+# Pin to a specific version. Check https://github.com/rhysd/actionlint/releases for newer releases.
+ACTIONLINT_VERSION="1.7.11"
+
+# Download the binary and checksums file separately (do NOT pipe directly into tar)
+curl -fsSLO "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+curl -fsSLO "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_checksums.txt"
+
+# Verify SHA-256 checksum before extracting — abort if verification fails
+sha256sum --check --ignore-missing "actionlint_${ACTIONLINT_VERSION}_checksums.txt"
+
+# (Recommended) Also verify the artifact attestation using GitHub CLI (requires gh >= 2.49)
+# gh attestation verify --repo rhysd/actionlint "actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+
+# Extract and install only after successful verification
+tar xzf "actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" -C /tmp actionlint
+sudo install -m 755 /tmp/actionlint /usr/local/bin/actionlint
+
+# Clean up downloaded artifacts
+rm "actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" "actionlint_${ACTIONLINT_VERSION}_checksums.txt"
 
 # Install GitHub CLI (optional, for additional validation)
 curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \

--- a/knowledge/migration-standards.md
+++ b/knowledge/migration-standards.md
@@ -58,14 +58,16 @@ Every migration must produce the following deliverables:
 
 ### 8. Migration Documentation
 
-- Create a Pull Request with the completed migration report as the PR body
+- Always create `.github/ci-archive/MIGRATION-README.md` with the completed migration report
+- Additionally deliver the report via Pull Request: check for an existing PR on the current branch, update its body if found, or create a new PR if not
+- If the PR cannot be created or updated, the `MIGRATION-README.md` file serves as the sole report
 - Fill all template sections with real data
 - No placeholders or incomplete sections
 - Include actual validation output
 
 ## 📋 Archival & Documentation Protocol
 
-⚠️ **MIGRATION IS NOT COMPLETE UNTIL A PULL REQUEST IS CREATED WITH THE COMPLETED MIGRATION REPORT AS THE PR BODY**
+⚠️ **MIGRATION IS NOT COMPLETE UNTIL `.github/ci-archive/MIGRATION-README.md` IS CREATED AND THE MIGRATION REPORT HAS BEEN DELIVERED VIA PULL REQUEST WHERE POSSIBLE**
 
 ### File Archival Process
 
@@ -96,9 +98,16 @@ Files must be **MOVED** (not copied) to the archive. Files must be **REMOVED** f
 
 ### Documentation Requirements
 
-#### Step 4: Create Migration Pull Request
+#### Step 4: Deliver Migration Report
 
-Create a Pull Request with the complete migration report as the PR body, using the appropriate template:
+**Always** create `.github/ci-archive/MIGRATION-README.md` with the completed report. Additionally, deliver the report via Pull Request:
+
+1. **Check for an existing Pull Request** on the current branch using the GitHub MCP tool
+2. **If a PR already exists** → update the PR body with the completed report template
+3. **If no PR exists** → create a new Pull Request using the completed report template as the PR body
+4. **If the PR cannot be created or updated** (e.g., MCP tool unavailable, insufficient permissions, no remote branch) → the `MIGRATION-README.md` already created above serves as the report
+
+Use the appropriate report template for your CI system:
 
 - [Azure DevOps Migration Report Template](knowledge/report-template/azure-devops.md)
 - [Bamboo Migration Report Template](knowledge/report-template/bamboo.md)

--- a/knowledge/migration-standards.md
+++ b/knowledge/migration-standards.md
@@ -226,11 +226,12 @@ Before ending any migration conversation, verify ALL items are complete:
 5. [ ] **Performance Optimization**: Added caching and parallelization improvements
 6. [ ] **File Archival**: MOVED original CI/CD files to `.github/ci-archive/`
 7. [ ] **Original File Cleanup**: VERIFIED no CI/CD files remain in original locations
-8. [ ] **Migration Pull Request**: CREATED PULL REQUEST WITH COMPLETE MIGRATION REPORT AS PR BODY
-9. [ ] **Validation Results**: INCLUDED ACTUAL VALIDATION OUTPUT IN PR BODY
-10. [ ] **Migration Report**: FILLED ALL SECTIONS OF REPORT TEMPLATE IN PR BODY
+8. [ ] **Archived Migration Report**: VERIFIED `.github/ci-archive/MIGRATION-README.md` EXISTS AND IS COMPLETE
+9. [ ] **Migration Pull Request**: CREATED PULL REQUEST WITH COMPLETE MIGRATION REPORT AS PR BODY
+10. [ ] **Validation Results**: INCLUDED ACTUAL VALIDATION OUTPUT IN PR BODY
+11. [ ] **Migration Report**: FILLED ALL SECTIONS OF REPORT TEMPLATE IN PR BODY
 
-⛔ **MIGRATION IS NOT COMPLETE UNTIL ALL 10 ITEMS ARE CHECKED**
+⛔ **MIGRATION IS NOT COMPLETE UNTIL ALL 11 ITEMS ARE CHECKED**
 
 ## Quality Standards
 

--- a/knowledge/migration-standards.md
+++ b/knowledge/migration-standards.md
@@ -7,30 +7,35 @@ This document defines the mandatory deliverables, archival protocols, and comple
 Every migration must produce the following deliverables:
 
 ### 1. Complete Workflows
+
 - Runnable GitHub Actions workflow files (`.github/workflows/*.yml`)
 - Workflows that replicate source functionality accurately
 - Proper job dependencies and execution order
 - Appropriate triggers matching original behavior
 
 ### 2. Secret and Variable Migration
+
 - Convert source CI secrets to GitHub Secrets
 - Convert environment variables to GitHub Variables
 - Document all required secrets and variables
 - Provide clear configuration instructions
 
 ### 3. Conversion Explanations
+
 - Clear documentation of migration decisions
 - Explanation of behavioral changes (if any)
 - Notes on platform differences and workarounds
 - Comments in workflow files explaining conversion choices
 
 ### 4. Validation Results
+
 - Execute linting (actionlint) with real output
 - Include validation results in migration report
 - Document any warnings or issues found
 - Provide resolution steps for validation failures
 
 ### 5. Security Improvements
+
 - Maintain original functionality while enhancing security
 - Implement least-privilege permissions
 - Use verified marketplace actions only
@@ -38,30 +43,34 @@ Every migration must produce the following deliverables:
 - Separate sensitive credentials using appropriate storage types
 
 ### 6. Performance Optimizations
+
 - Suggest caching strategies for dependencies
 - Recommend parallelization opportunities
 - Optimize job execution order
 - Suggestions that don't alter core behavior
 
 ### 7. File Archival
+
 - **MOVE** original CI/CD files to `.github/ci-archive/`
 - **DELETE** files from original locations (not copy)
 - Preserve original files for reference only
 - Ensure no CI/CD conflicts remain
 
 ### 8. Migration Documentation
-- Create comprehensive MIGRATION-README.md
+
+- Create a Pull Request with the completed migration report as the PR body
 - Fill all template sections with real data
 - No placeholders or incomplete sections
 - Include actual validation output
 
 ## 📋 Archival & Documentation Protocol
 
-⚠️ **MIGRATION IS NOT COMPLETE UNTIL MIGRATION-README.md IS CREATED WITH REAL DATA**
+⚠️ **MIGRATION IS NOT COMPLETE UNTIL A PULL REQUEST IS CREATED WITH THE COMPLETED MIGRATION REPORT AS THE PR BODY**
 
 ### File Archival Process
 
 **Step 1: Create Archive Directory**
+
 ```bash
 mkdir -p .github/ci-archive/
 ```
@@ -71,6 +80,7 @@ mkdir -p .github/ci-archive/
 Files must be **MOVED** (not copied) to the archive. Files must be **REMOVED** from original locations:
 
 **Examples by CI System:**
+
 - Drone CI: `.drone.yml` → `.github/ci-archive/.drone.yml` (DELETE original)
 - Jenkins: `Jenkinsfile` → `.github/ci-archive/Jenkinsfile` (DELETE original)
 - CircleCI: `.circleci/config.yml` → `.github/ci-archive/circleci-config.yml` (DELETE original directory)
@@ -79,15 +89,17 @@ Files must be **MOVED** (not copied) to the archive. Files must be **REMOVED** f
 - Azure Pipelines: `azure-pipelines.yml` → `.github/ci-archive/azure-pipelines.yml` (DELETE original)
 
 **Step 3: Verify Cleanup**
+
 - **VERIFY** no CI/CD files remain in root directory or anywhere else
 - **ENSURE** CI/CD files exist ONLY in `.github/ci-archive/`
 - Check for hidden directories (`.circleci/`, `.github/workflows/` conflicts)
 
 ### Documentation Requirements
 
-**Step 4: Create Migration Report**
+**Step 4: Create Migration Pull Request**
 
-Create `.github/ci-archive/MIGRATION-README.md` with complete migration report using the appropriate template:
+Create a Pull Request with the complete migration report as the PR body, using the appropriate template:
+
 - [DroneCI Migration Report Template](docs/report-template/droneci.md)
 - [Jenkins Migration Report Template](docs/report-template/jenkins.md) *(if exists)*
 - [CircleCI Migration Report Template](docs/report-template/circleci.md) *(if exists)*
@@ -96,6 +108,7 @@ Create `.github/ci-archive/MIGRATION-README.md` with complete migration report u
 **Step 5: Execute Validation**
 
 Execute validation steps and include **real output** in README:
+
 ```bash
 # Run actionlint
 actionlint .github/workflows/*.yml
@@ -107,6 +120,7 @@ actionlint .github/workflows/*.yml > validation-output.txt 2>&1
 **Step 6: Fill Template Sections**
 
 Fill in all metrics, diagrams, and checklists with **actual data**:
+
 - Migration overview metrics (before/after comparison)
 - Conversion diagrams (mermaid charts)
 - Step conversion mappings
@@ -122,7 +136,7 @@ Ensure the report is well-formatted, readable, and comprehensive.
 
 ## 🔒 MANDATORY Validation Output Integration
 
-When creating the MIGRATION-README.md report, you MUST:
+When creating the migration Pull Request, you MUST:
 
 1. **EXECUTE** actionlint and include actual output in the report
 2. **CALCULATE** and fill in the metrics table with real data from the migration
@@ -139,7 +153,9 @@ When creating the MIGRATION-README.md report, you MUST:
 
 ### Linting Results:
 ```
+
 [Paste actual actionlint output here - no placeholders]
+
 ```
 
 ### Manual Verification Checklist:
@@ -160,6 +176,7 @@ When creating the MIGRATION-README.md report, you MUST:
 ### Required Tools
 
 Inform users they need these tools for proper validation (Linux only):
+
 ```bash
 # Install actionlint for YAML linting
 curl -sL https://github.com/rhymond/actionlint/releases/latest/download/actionlint_linux_amd64.tar.gz | tar xz -C /tmp && sudo mv /tmp/actionlint /usr/local/bin/
@@ -175,7 +192,9 @@ sudo apt update && sudo apt install gh
 To ensure the correctness and security of your migrated GitHub Actions workflows:
 
 #### 1. Syntax Linting
+
 Execute actionlint for GitHub Actions YAML validation:
+
 ```bash
 # Using actionlint (recommended)
 actionlint .github/workflows/your-workflow.yml
@@ -194,15 +213,16 @@ Before ending any migration conversation, verify ALL items are complete:
 5. [ ] **Performance Optimization**: Added caching and parallelization improvements
 6. [ ] **File Archival**: MOVED original CI/CD files to `.github/ci-archive/`
 7. [ ] **Original File Cleanup**: VERIFIED no CI/CD files remain in original locations
-8. [ ] **Migration README Creation**: CREATED `.github/ci-archive/MIGRATION-README.md` WITH COMPLETE REPORT
-9. [ ] **Validation Results**: INCLUDED ACTUAL VALIDATION OUTPUT IN README
-10. [ ] **Migration Report**: FILLED ALL SECTIONS OF README TEMPLATE
+8. [ ] **Migration Pull Request**: CREATED PULL REQUEST WITH COMPLETE MIGRATION REPORT AS PR BODY
+9. [ ] **Validation Results**: INCLUDED ACTUAL VALIDATION OUTPUT IN PR BODY
+10. [ ] **Migration Report**: FILLED ALL SECTIONS OF REPORT TEMPLATE IN PR BODY
 
 ⛔ **MIGRATION IS NOT COMPLETE UNTIL ALL 10 ITEMS ARE CHECKED**
 
 ## Quality Standards
 
 ### Documentation Quality
+
 - Clear, concise explanations
 - Accurate technical details
 - Complete coverage of all changes
@@ -210,6 +230,7 @@ Before ending any migration conversation, verify ALL items are complete:
 - No typos or grammatical errors
 
 ### Code Quality
+
 - Valid YAML syntax
 - Proper indentation and formatting
 - Meaningful job and step names
@@ -217,6 +238,7 @@ Before ending any migration conversation, verify ALL items are complete:
 - Follows GitHub Actions best practices
 
 ### Validation Quality
+
 - Real output from validation tools
 - All warnings addressed or documented
 - Known issues clearly explained

--- a/knowledge/migration-workflow.md
+++ b/knowledge/migration-workflow.md
@@ -5,11 +5,13 @@ This document outlines the standard 5-phase workflow for migrating CI/CD pipelin
 ## Phase 1: Source Requirement (FIRST)
 
 **Critical First Step:**
+
 - **ALWAYS** request the existing CI/CD configuration file(s) if not provided
 - **REFUSE** to proceed without actual source configuration files
 - **NEVER** create workflows based on descriptions or assumptions
 
 **What to Look For:**
+
 - Drone CI: `.drone.yml`, `.drone.yaml`
 - Jenkins: `Jenkinsfile`, `*.jenkinsfile`, YAML pipeline configs, shared library files
 - CircleCI: `.circleci/config.yml`
@@ -21,6 +23,7 @@ This document outlines the standard 5-phase workflow for migrating CI/CD pipelin
 ## Phase 2: Analysis Phase
 
 **Thorough Examination:**
+
 1. Examine provided configuration files thoroughly
 2. Identify pipeline structure, dependencies, and complexity
 3. Note CI-system-specific features being used
@@ -30,6 +33,7 @@ This document outlines the standard 5-phase workflow for migrating CI/CD pipelin
 7. Map agents/executors/containers to GitHub runners
 
 **Key Analysis Points:**
+
 - Pipeline/workflow orchestration and job dependencies
 - Build tools, plugins, and external integrations
 - Credential bindings, secrets, and environment variables
@@ -40,6 +44,7 @@ This document outlines the standard 5-phase workflow for migrating CI/CD pipelin
 ## Phase 3: Conversion Phase
 
 **Core Conversion Principles:**
+
 - Convert **ONLY** the functionality present in the source configuration
 - Maintain equivalent behavior and functionality
 - **Use ONLY existing verified GitHub Actions** from verified creators on [GitHub Marketplace](https://github.com/marketplace?type=actions)
@@ -50,6 +55,7 @@ This document outlines the standard 5-phase workflow for migrating CI/CD pipelin
 - Suggest optimizations while preserving original intent
 
 **Conversion Tasks:**
+
 - Map CI-specific steps to GitHub Actions equivalents
 - Convert triggers and event filters to GitHub Actions `on:` syntax
 - Translate conditional logic to GitHub Actions expressions
@@ -61,6 +67,7 @@ This document outlines the standard 5-phase workflow for migrating CI/CD pipelin
 ## Phase 4: Validation Phase
 
 **Testing and Verification:**
+
 1. Execute actionlint for YAML syntax validation
 2. Verify all job dependencies are correctly defined
 3. Break down complex pipelines into manageable chunks
@@ -69,6 +76,7 @@ This document outlines the standard 5-phase workflow for migrating CI/CD pipelin
 6. Validate secrets and variable references
 
 **Validation Checklist:**
+
 - [ ] YAML syntax is valid (no parsing errors)
 - [ ] All required actions are available and using latest stable versions
 - [ ] All actions are from verified creators on GitHub Marketplace
@@ -82,16 +90,18 @@ For complete validation requirements and tool setup, see [Workflow Validation Re
 ## Phase 5: Documentation Phase (FINAL)
 
 **Complete Migration Documentation:**
-1. **MANDATORY**: Create `.github/ci-archive/MIGRATION-README.md`
+
+1. **MANDATORY**: Create a Pull Request using the appropriate report template as the PR body
 2. Include actual validation output, not placeholders
 3. **MOVE** original CI/CD files to `.github/ci-archive/` (DELETE from original locations)
 4. **VERIFY** no original CI/CD files remain in root directory or elsewhere
-5. Complete all sections of the migration report template
+5. Complete all sections of the migration report template in the PR body
 6. Document all secrets and variables that need to be configured
 7. Provide next steps for team adoption
 
 **Documentation Standards:**
-- Use the appropriate report template for your CI system
+
+- Use the appropriate report template for your CI system as the PR body
 - Fill all sections with actual migration data (no placeholders)
 - Include real validation output (actionlint results)
 - Create mermaid diagrams reflecting actual pipeline structure
@@ -103,9 +113,10 @@ See the [Report Templates](docs/report-template/) for CI-system-specific templat
 ## Workflow Completion
 
 A migration is **NOT COMPLETE** until:
+
 - All 5 phases have been executed in order
 - Validation has been performed with real output
-- MIGRATION-README.md has been created with complete data
+- A Pull Request has been created with the completed migration report as the PR body
 - Original CI/CD files have been archived and removed from original locations
 - All deliverables have been provided to the user
 

--- a/knowledge/migration-workflow.md
+++ b/knowledge/migration-workflow.md
@@ -91,24 +91,34 @@ For complete validation requirements and tool setup, see [Workflow Validation Re
 
 **Complete Migration Documentation:**
 
-1. **MANDATORY**: Create a Pull Request using the appropriate report template as the PR body
-2. Include actual validation output, not placeholders
-3. **MOVE** original CI/CD files to `.github/ci-archive/` (DELETE from original locations)
-4. **VERIFY** no original CI/CD files remain in root directory or elsewhere
-5. Complete all sections of the migration report template in the PR body
-6. Document all secrets and variables that need to be configured
-7. Provide next steps for team adoption
+1. **MANDATORY**: Create `.github/ci-archive/MIGRATION-README.md` with the completed report
+2. **MANDATORY**: Deliver the migration report via the Pull Request workflow below
+3. Include actual validation output, not placeholders
+4. **MOVE** original CI/CD files to `.github/ci-archive/` (DELETE from original locations)
+5. **VERIFY** no original CI/CD files remain in root directory or elsewhere
+6. Complete all sections of the migration report template
+7. Document all secrets and variables that need to be configured
+8. Provide next steps for team adoption
+
+### Pull Request Workflow
+
+The `MIGRATION-README.md` file is **always created** in `.github/ci-archive/` as a permanent reference. Additionally, deliver the report via Pull Request:
+
+1. **Check for an existing Pull Request** on the current branch using the GitHub MCP tool
+2. **If a PR already exists** → update the PR body with the completed report template
+3. **If no PR exists** → create a new Pull Request using the completed report template as the PR body
+4. **If the PR cannot be created or updated** (e.g., MCP tool unavailable, insufficient permissions, no remote branch) → the `MIGRATION-README.md` file already created in step 1 above serves as the report
 
 **Documentation Standards:**
 
-- Use the appropriate report template for your CI system as the PR body
+- Use the appropriate report template for your CI system
 - Fill all sections with actual migration data (no placeholders)
 - Include real validation output (actionlint results)
 - Create mermaid diagrams reflecting actual pipeline structure
 - Document project-specific secrets and variables
 - Capture migration notes, decisions, and considerations
 
-See the [Report Templates](docs/report-template/) for CI-system-specific templates.
+See the [Report Templates](knowledge/report-template/) for CI-system-specific templates.
 
 ## Workflow Completion
 
@@ -116,7 +126,8 @@ A migration is **NOT COMPLETE** until:
 
 - All 5 phases have been executed in order
 - Validation has been performed with real output
-- A Pull Request has been created with the completed migration report as the PR body
+- `.github/ci-archive/MIGRATION-README.md` has been created with the completed report
+- The migration report has been delivered via PR (created or updated) where possible
 - Original CI/CD files have been archived and removed from original locations
 - All deliverables have been provided to the user
 

--- a/knowledge/patterns/jenkins/secrets.md
+++ b/knowledge/patterns/jenkins/secrets.md
@@ -513,7 +513,7 @@ When migrating Jenkins credentials to GitHub Actions:
 - [ ] Convert credential bindings to environment variables
 - [ ] Update secret references in workflow files
 - [ ] Test credential access in non-production environment first
-- [ ] Document all required secrets in MIGRATION-README.md
+- [ ] Document all required secrets in the migration Pull Request
 - [ ] Remove or archive Jenkins credentials after successful migration
 - [ ] Update team documentation with new secret management process
 - [ ] Implement secret rotation schedule
@@ -522,16 +522,21 @@ When migrating Jenkins credentials to GitHub Actions:
 ## Troubleshooting
 
 ### Issue: Credential Not Available in Step
+
 **Solution**: Ensure secret is defined at correct scope (environment, repository, organization)
 
 ### Issue: Secret Value Contains Special Characters
+
 **Solution**: Use base64 encoding for complex secrets or escape properly in shell
 
 ### Issue: Need Dynamic Credential Selection
+
 **Solution**: Use environment-based deployments or matrix strategy with conditional logic
 
 ### Issue: Shared Credentials Across Teams
+
 **Solution**: Use organization-level secrets with repository access control
 
 ### Issue: Credential Rotation
+
 **Solution**: Update secrets in GitHub settings; workflows pick up new values automatically

--- a/knowledge/patterns/travisci/secrets.md
+++ b/knowledge/patterns/travisci/secrets.md
@@ -520,7 +520,7 @@ When migrating Travis CI encrypted variables and environment variables:
 - [ ] Update workflow files to reference secrets with `${{ secrets.* }}`
 - [ ] Use variables with `${{ vars.* }}` for non-sensitive configuration
 - [ ] Test secret access in non-production environment first
-- [ ] Document all required secrets in MIGRATION-README.md
+- [ ] Document all required secrets in the migration Pull Request
 - [ ] Set up environment protection rules for production deployments
 - [ ] Remove or archive Travis CI encrypted variables after migration
 - [ ] Update team documentation with new secret management process
@@ -609,16 +609,21 @@ jobs:
 ## Troubleshooting
 
 ### Issue: Secret Not Available in Workflow
+
 **Solution**: Verify secret is created at correct scope (repository/organization/environment)
 
 ### Issue: Secret Value Has Special Characters
+
 **Solution**: Use base64 encoding or ensure proper escaping in shell scripts
 
 ### Issue: Need Different Secrets Per Environment
+
 **Solution**: Use GitHub Environments with environment-specific secrets
 
 ### Issue: Secret Appears in Logs
+
 **Solution**: Use `::add-mask::` or avoid echoing variables that contain secrets
 
 ### Issue: Deployment Provider Credentials
+
 **Solution**: Check marketplace for official actions that handle authentication securely

--- a/knowledge/report-template/azure-devops.md
+++ b/knowledge/report-template/azure-devops.md
@@ -1,8 +1,8 @@
-## 📄 MIGRATION REPORT TEMPLATE
+# 📄 MIGRATION REPORT TEMPLATE
 
-Create `.github/ci-archive/MIGRATION-README.md` with this complete template:
+Use the following as the Pull Request body:
 
-```markdown
+````markdown
 # 🚀 Azure DevOps to GitHub Actions Migration Report
 
 ## 📊 Migration Overview
@@ -42,14 +42,16 @@ graph LR
 
 ## 🔧 Key Transformations
 
-### Stage/Job Conversions:
+### Stage/Job Conversions
+
 - Azure DevOps stages → GitHub Actions jobs with `needs:` dependencies
 - Azure DevOps jobs → GitHub Actions job steps
 - Template expansions → Inline workflow code
 - Pool specifications → `runs-on:` runner selections
 - Azure DevOps tasks → Equivalent GitHub Actions or shell commands
 
-### Task and Variable Mappings:
+### Task and Variable Mappings
+
 - `NodeTool@0` → `actions/setup-node@v4`
 - `DotNetCoreCLI@2` → `actions/setup-dotnet@v4` + `run` commands
 - `PublishBuildArtifacts@1` → `actions/upload-artifact@v4`
@@ -57,7 +59,8 @@ graph LR
 - Variable groups → Environment variables and organization/repository secrets and variables
 - Deployment environments → GitHub Actions environments with protection rules
 
-### Structural Changes:
+### Structural Changes
+
 - Expanded all template references inline
 - Converted `dependsOn:` to `needs:` for job dependencies
 - Enhanced security with proper secret and variable management
@@ -66,12 +69,14 @@ graph LR
 
 ## ✅ Validation Results
 
-### Linting Results:
+### Linting Results
+
 ```
 [VALIDATION_OUTPUT_ACTIONLINT]
 ```
 
-### Manual Verification Checklist:
+### Manual Verification Checklist
+
 - [x] YAML syntax validated
 - [x] All actions properly versioned
 - [x] Job dependencies verified
@@ -98,13 +103,15 @@ graph LR
 
 ## 🔗 Variable and Secret Requirements
 
-### Required GitHub Secrets:
+### Required GitHub Secrets
+
 - `DATABASE_CONNECTION_STRING` - Database connection string (from Azure DevOps variable groups)
 - `API_KEY` - Application API key
 - `DEPLOYMENT_TOKEN` - Deployment service token
 - [List other project-specific secrets migrated from Azure DevOps]
 
-### Required GitHub Variables:
+### Required GitHub Variables
+
 - `BUILD_CONFIGURATION` - Build configuration (Release/Debug)
 - `API_ENDPOINT` - Application API endpoint
 - `TARGET_ENVIRONMENT` - Deployment target environment
@@ -120,9 +127,10 @@ graph LR
 
 ## 📁 Original Azure DevOps Files
 
-The original Azure DevOps pipeline files have been moved to [`.github/ci-archive/`](.github/ci-archive/) for reference.
+The original Azure DevOps pipeline files have been moved to `.github/ci-archive/` for reference:
 
-For a complete record of this migration, see [MIGRATION-README.md](.github/ci-archive/MIGRATION-README.md) in the archive folder.
+- `azure-pipelines.yml` → [`.github/ci-archive/azure-pipelines.yml`](.github/ci-archive/azure-pipelines.yml)
+- Pipeline templates → [`.github/ci-archive/`](.github/ci-archive/) with preserved structure
 
 ## 📚 Migration Notes
 
@@ -131,4 +139,5 @@ For a complete record of this migration, see [MIGRATION-README.md](.github/ci-ar
 
 ---
 *Migration completed by GitHub Copilot Azure DevOps Migration Agent*
-```
+
+````

--- a/knowledge/report-template/azure-devops.md
+++ b/knowledge/report-template/azure-devops.md
@@ -1,6 +1,6 @@
 # 📄 MIGRATION REPORT TEMPLATE
 
-Use the following as the Pull Request body:
+Use the following content in `.github/ci-archive/MIGRATION-README.md` and as the Pull Request body:
 
 ````markdown
 # 🚀 Azure DevOps to GitHub Actions Migration Report

--- a/knowledge/report-template/bamboo.md
+++ b/knowledge/report-template/bamboo.md
@@ -1,9 +1,8 @@
+# 📄 MIGRATION REPORT TEMPLATE
+
+Use the following as the Pull Request body:
+
 ````markdown
-## 📄 MIGRATION REPORT TEMPLATE
-
-Create `.github/ci-archive/MIGRATION-README.md` with this complete template:
-
-```markdown
 # 🚀 Bamboo to GitHub Actions Migration Report
 
 ## 📊 Migration Overview
@@ -18,7 +17,7 @@ Create `.github/ci-archive/MIGRATION-README.md` with this complete template:
 ## 🔄 Conversion Diagram
 
 ```mermaid
-graph TD
+graph LR
     A[Bamboo Build Plan] --> B[GitHub Actions Workflow]
     C[Bamboo Deployment Project] --> D[GitHub Actions Deployment Workflow]
 
@@ -44,14 +43,16 @@ graph TD
 
 ## 🔧 Key Transformations
 
-### Build Plan Conversions:
+### Build Plan Conversions
+
 - Bamboo stages → GitHub Actions jobs with `needs:` dependencies
 - Bamboo jobs → GitHub Actions job steps
 - Bamboo tasks → Equivalent GitHub Actions or shell commands
 - Agent capabilities → `runs-on:` runner selections
 - Plan dependencies → Job dependencies with `needs:`
 
-### Task and Variable Mappings:
+### Task and Variable Mappings
+
 - `script` tasks → `run` steps
 - `artifact-definition` → `actions/upload-artifact@v4`
 - `artifact-download` → `actions/download-artifact@v4`
@@ -59,7 +60,8 @@ graph TD
 - Global variables → GitHub Variables and Secrets
 - Repository polling → GitHub webhook triggers
 
-### Structural Changes:
+### Structural Changes
+
 - Expanded all shared configurations inline
 - Converted plan dependencies to job dependencies
 - Enhanced security with proper secret and variable management
@@ -69,12 +71,14 @@ graph TD
 
 ## ✅ Validation Results
 
-### Linting Results:
+### Linting Results
+
 ```
 [VALIDATION_OUTPUT_ACTIONLINT]
 ```
 
-### Manual Verification Checklist:
+### Manual Verification Checklist
+
 - [x] YAML syntax validated
 - [x] All actions properly versioned with latest stable versions
 - [x] Job dependencies verified
@@ -107,13 +111,15 @@ graph TD
 
 ## 🔗 Variable and Secret Requirements
 
-### Required GitHub Secrets:
+### Required GitHub Secrets
+
 - `DATABASE_PASSWORD` - Database connection password (from Bamboo global variables)
 - `API_SECRET_KEY` - Application API secret key
 - `DEPLOYMENT_TOKEN` - Deployment service token
 - [List other project-specific secrets migrated from Bamboo]
 
-### Required GitHub Variables:
+### Required GitHub Variables
+
 - `API_ENDPOINT` - Application API endpoint URL
 - `BUILD_CONFIGURATION` - Build configuration (release/debug)
 - `TARGET_ENVIRONMENT` - Deployment target environment
@@ -135,6 +141,7 @@ graph TD
 ## 📁 Original Bamboo Files
 
 The original Bamboo configuration files have been moved to `.github/ci-archive/` for reference:
+
 - `bamboo-specs/` → [`.github/ci-archive/bamboo-specs/`](.github/ci-archive/bamboo-specs/)
 - Build plans → [`.github/ci-archive/`](.github/ci-archive/)
 - Deployment projects → [`.github/ci-archive/`](.github/ci-archive/)
@@ -148,6 +155,5 @@ The original Bamboo configuration files have been moved to `.github/ci-archive/`
 
 ---
 *Migration completed by GitHub Copilot Bamboo Migration Agent*
-```
 
 ````

--- a/knowledge/report-template/bamboo.md
+++ b/knowledge/report-template/bamboo.md
@@ -1,6 +1,6 @@
 # 📄 MIGRATION REPORT TEMPLATE
 
-Use the following as the Pull Request body:
+Use the following as both the Pull Request body and the contents of `.github/ci-archive/MIGRATION-README.md` (create the file if it does not exist):
 
 ````markdown
 # 🚀 Bamboo to GitHub Actions Migration Report

--- a/knowledge/report-template/bitbucket.md
+++ b/knowledge/report-template/bitbucket.md
@@ -1,3 +1,8 @@
+# 📄 MIGRATION REPORT TEMPLATE
+
+Use the following as the Pull Request body:
+
+````markdown
 # 🚀 Bitbucket Pipelines to GitHub Actions Migration Report
 
 ## 📊 Migration Overview
@@ -13,7 +18,7 @@
 ## 🔄 Conversion Diagram
 
 ```mermaid
-graph TD
+graph LR
     A[Bitbucket Pipeline] --> B[GitHub Actions Workflow]
     C[Parallel Steps] --> D[Separate Jobs]
 
@@ -44,26 +49,30 @@ graph TD
 
 ## 🔧 Key Transformations
 
-### Step Conversions:
+### Step Conversions
+
 - Bitbucket steps → GitHub Actions jobs and steps
 - Parallel sections → Separate jobs with dependency management
 - Custom steps → Expanded inline workflow code
 - Container images → `runs-on` with container specifications
 - Bitbucket services → GitHub Actions service containers
 
-### Variable and Secret Mappings:
+### Variable and Secret Mappings
+
 - Secured repository variables → GitHub Secrets
 - Regular repository variables → GitHub Variables
 - Deployment variables → Environment-specific variables/secrets
 - Built-in variables → GitHub context variables (`github.run_number`, etc.)
 
-### Service and Environment Mappings:
+### Service and Environment Mappings
+
 - Bitbucket services → GitHub Actions service containers
 - Deployment environments → GitHub Actions environments with protection rules
 - Cache definitions → GitHub Actions cache actions
 - Manual triggers → GitHub Actions workflow_dispatch
 
-### Structural Changes:
+### Structural Changes
+
 - Expanded all custom step references inline
 - Converted parallel execution to separate jobs with proper dependencies
 - Enhanced security with proper secret and variable management
@@ -73,12 +82,14 @@ graph TD
 
 ## ✅ Validation Results
 
-### Linting Results:
+### Linting Results
+
 ```
 [VALIDATION_OUTPUT_ACTIONLINT]
 ```
 
-### Manual Verification Checklist:
+### Manual Verification Checklist
+
 - [x] YAML syntax validated
 - [x] All actions properly versioned with latest stable versions
 - [x] Job dependencies verified for parallel execution conversion
@@ -114,14 +125,16 @@ graph TD
 
 ## 🔗 Variable and Secret Requirements
 
-### Required GitHub Secrets:
+### Required GitHub Secrets
+
 - `DATABASE_PASSWORD` - Database connection password (from Bitbucket secured variables)
 - `API_SECRET_KEY` - Application API secret key
 - `DEPLOYMENT_TOKEN` - Deployment service token
 - `DOCKER_HUB_PASSWORD` - Docker Hub authentication
 - [List other project-specific secrets migrated from Bitbucket]
 
-### Required GitHub Variables:
+### Required GitHub Variables
+
 - `API_ENDPOINT` - Application API endpoint URL
 - `BUILD_CONFIGURATION` - Build configuration (release/debug)
 - `TARGET_ENVIRONMENT` - Deployment target environment
@@ -145,6 +158,7 @@ graph TD
 ## 📁 Original Bitbucket Files
 
 The original Bitbucket Pipelines configuration files have been moved to `.github/ci-archive/` for reference:
+
 - `bitbucket-pipelines.yml` → [`.github/ci-archive/bitbucket-pipelines.yml`](.github/ci-archive/bitbucket-pipelines.yml)
 - Custom steps → [`.github/ci-archive/custom-steps/`](.github/ci-archive/custom-steps/)
 
@@ -157,3 +171,5 @@ The original Bitbucket Pipelines configuration files have been moved to `.github
 
 ---
 *Migration completed by GitHub Copilot Bitbucket Pipelines Migration Agent*
+
+````

--- a/knowledge/report-template/bitbucket.md
+++ b/knowledge/report-template/bitbucket.md
@@ -1,6 +1,6 @@
 # 📄 MIGRATION REPORT TEMPLATE
 
-Use the following as the Pull Request body:
+Use the following as the Pull Request body and as the contents of `.github/ci-archive/MIGRATION-README.md`:
 
 ````markdown
 # 🚀 Bitbucket Pipelines to GitHub Actions Migration Report

--- a/knowledge/report-template/circleci.md
+++ b/knowledge/report-template/circleci.md
@@ -1,6 +1,6 @@
 # 📄 MIGRATION REPORT TEMPLATE
 
-Use the following as the Pull Request body:
+Use the following content both as the Pull Request body and as the contents of `.github/ci-archive/MIGRATION-README.md`:
 
 ````markdown
 # 🚀 CircleCI to GitHub Actions Migration Report

--- a/knowledge/report-template/circleci.md
+++ b/knowledge/report-template/circleci.md
@@ -1,8 +1,8 @@
-## 📄 MIGRATION REPORT TEMPLATE
+# 📄 MIGRATION REPORT TEMPLATE
 
-Create `.github/ci-archive/MIGRATION-README.md` with this complete template:
+Use the following as the Pull Request body:
 
-```markdown
+````markdown
 # 🚀 CircleCI to GitHub Actions Migration Report
 
 ## 📊 Migration Overview
@@ -42,20 +42,23 @@ graph LR
 
 ## 🔧 Key Transformations
 
-### Job Conversions:
+### Job Conversions
+
 - CircleCI executors → GitHub Actions `runs-on:` and `container:`
 - CircleCI orbs → Expanded inline or marketplace actions
 - CircleCI commands → Reusable steps or composite actions
 - CircleCI workflow dependencies → GitHub Actions `needs:`
 
-### Orb and Context Mappings:
+### Orb and Context Mappings
+
 - `circleci/node@x` → `actions/setup-node@v4`
 - `circleci/aws-cli@x` → `aws-actions/configure-aws-credentials@v4`
 - `circleci/docker@x` → `docker/build-push-action@v5`
 - CircleCI contexts → GitHub Secrets and Variables
 - Environment variables → GitHub Variables for non-sensitive, Secrets for sensitive data
 
-### Structural Changes:
+### Structural Changes
+
 - Expanded all orb references inline
 - Converted `requires:` to `needs:` for job dependencies
 - Enhanced security with proper secret and variable management
@@ -64,12 +67,14 @@ graph LR
 
 ## ✅ Validation Results
 
-### Linting Results:
+### Linting Results
+
 ```
 [VALIDATION_OUTPUT_ACTIONLINT]
 ```
 
-### Manual Verification Checklist:
+### Manual Verification Checklist
+
 - [x] YAML syntax validated
 - [x] All actions properly versioned
 - [x] Job dependencies verified
@@ -96,14 +101,16 @@ graph LR
 
 ## 🔗 Variable and Secret Requirements
 
-### Required GitHub Secrets:
+### Required GitHub Secrets
+
 - `AWS_ACCESS_KEY_ID` - AWS access key for deployments (from CircleCI context)
 - `AWS_SECRET_ACCESS_KEY` - AWS secret key for deployments
 - `DOCKER_USER` - Docker Hub username
 - `DOCKER_PASS` - Docker Hub password or access token
 - [List other project-specific secrets migrated from CircleCI]
 
-### Required GitHub Variables:
+### Required GitHub Variables
+
 - `AWS_REGION` - AWS deployment region
 - `BUILD_CONFIGURATION` - Build configuration (release/debug)
 - `API_ENDPOINT` - Application API endpoint
@@ -119,9 +126,9 @@ graph LR
 
 ## 📁 Original CircleCI Files
 
-The original CircleCI configuration files have been moved to [`.github/ci-archive/`](.github/ci-archive/) for reference.
+The original CircleCI configuration files have been moved to `.github/ci-archive/` for reference:
 
-For a complete record of this migration, see [MIGRATION-README.md](.github/ci-archive/MIGRATION-README.md) in the archive folder.
+- `.circleci/config.yml` → [`.github/ci-archive/circleci-config.yml`](.github/ci-archive/circleci-config.yml)
 
 ## 📚 Migration Notes
 
@@ -130,4 +137,5 @@ For a complete record of this migration, see [MIGRATION-README.md](.github/ci-ar
 
 ---
 *Migration completed by GitHub Copilot CircleCI Migration Agent*
-```
+
+````

--- a/knowledge/report-template/droneci.md
+++ b/knowledge/report-template/droneci.md
@@ -1,6 +1,6 @@
 # 📄 MIGRATION REPORT TEMPLATE
 
-Use the following as the Pull Request body:
+Use the following as both the Pull Request body and the contents of `.github/ci-archive/MIGRATION-README.md`:
 
 ````markdown
 # 🚀 Drone CI to GitHub Actions Migration Report

--- a/knowledge/report-template/droneci.md
+++ b/knowledge/report-template/droneci.md
@@ -1,8 +1,8 @@
-## 📄 MIGRATION REPORT TEMPLATE
+# 📄 MIGRATION REPORT TEMPLATE
 
-Create `.github/ci-archive/MIGRATION-README.md` with this complete template:
+Use the following as the Pull Request body:
 
-```markdown
+````markdown
 # 🚀 Drone CI to GitHub Actions Migration Report
 
 ## 📊 Migration Overview
@@ -36,19 +36,22 @@ graph LR
 
 ## 🔧 Key Transformations
 
-### Step Conversions:
+### Step Conversions
+
 - `docker` steps → `docker/build-push-action@v5`
 - `slack` notification steps → `8398a7/action-slack@v3`
 - Custom command steps → `run` steps
 - Multi-command steps → combined job steps
 
-### Environment Variable and Secret Mappings:
+### Environment Variable and Secret Mappings
+
 - Drone CI secrets → GitHub Secrets for sensitive data
 - Drone CI environment variables → GitHub Variables for non-sensitive configuration
 - Environment-specific configuration → Repository or organization variables/secrets
 - Build metadata → GitHub context variables (`github.run_number`, etc.)
 
-### Structural Changes:
+### Structural Changes
+
 - Combined sequential steps into single jobs where appropriate
 - Improved caching with GitHub Actions cache
 - Enhanced security with proper secret and variable management
@@ -56,12 +59,14 @@ graph LR
 
 ## ✅ Validation Results
 
-### Linting Results:
+### Linting Results
+
 ```
 [VALIDATION_OUTPUT_ACTIONLINT]
 ```
 
-### Manual Verification Checklist:
+### Manual Verification Checklist
+
 - [x] YAML syntax validated
 - [x] All actions properly versioned
 - [x] Job dependencies verified
@@ -88,13 +93,15 @@ graph LR
 
 ## 🔗 Variable and Secret Requirements
 
-### Required GitHub Secrets:
+### Required GitHub Secrets
+
 - `API_SECRET` - Application API secret key (from Drone CI secrets)
 - `DATABASE_PASSWORD` - Database connection password
 - `DEPLOYMENT_TOKEN` - Deployment service token
 - [List other project-specific secrets migrated from Drone CI]
 
-### Required GitHub Variables:
+### Required GitHub Variables
+
 - `API_ENDPOINT` - Application API endpoint URL
 - `BUILD_CONFIGURATION` - Build configuration (release/debug)
 - `TARGET_ENVIRONMENT` - Deployment target environment
@@ -110,9 +117,9 @@ graph LR
 
 ## 📁 Original Drone CI Files
 
-The original Drone CI configuration files have been moved to [`.github/ci-archive/`](.github/ci-archive/) for reference.
+The original Drone CI configuration files have been moved to `.github/ci-archive/` for reference:
 
-For a complete record of this migration, see [MIGRATION-README.md](.github/ci-archive/MIGRATION-README.md) in the archive folder.
+- `.drone.yml` → [`.github/ci-archive/.drone.yml`](.github/ci-archive/.drone.yml)
 
 ## 📚 Migration Notes
 
@@ -121,4 +128,5 @@ For a complete record of this migration, see [MIGRATION-README.md](.github/ci-ar
 
 ---
 *Migration completed by GitHub Copilot Drone CI Migration Agent*
-```
+
+````

--- a/knowledge/report-template/gitlab.md
+++ b/knowledge/report-template/gitlab.md
@@ -1,6 +1,6 @@
 # 📄 MIGRATION REPORT TEMPLATE
 
-Use the following as the Pull Request body:
+Use the following as the Pull Request body and also save the completed report to `.github/ci-archive/MIGRATION-README.md` in the repository:
 
 ````markdown
 # 🚀 GitLab CI/CD to GitHub Actions Migration Report

--- a/knowledge/report-template/gitlab.md
+++ b/knowledge/report-template/gitlab.md
@@ -1,3 +1,8 @@
+# 📄 MIGRATION REPORT TEMPLATE
+
+Use the following as the Pull Request body:
+
+````markdown
 # 🚀 GitLab CI/CD to GitHub Actions Migration Report
 
 ## 📊 Migration Overview
@@ -13,7 +18,7 @@
 ## 🔄 Conversion Diagram
 
 ```mermaid
-graph TD
+graph LR
     A[GitLab CI/CD Pipeline] --> B[GitHub Actions Workflow]
 
     subgraph "GitLab CI/CD Structure"
@@ -41,7 +46,8 @@ graph TD
 
 ## 🔧 Key Transformations
 
-### Stage/Job Conversions:
+### Stage/Job Conversions
+
 - GitLab stages → GitHub Actions jobs with `needs:` dependencies
 - GitLab jobs → GitHub Actions job steps
 - Include expansions → Inline workflow code
@@ -49,14 +55,16 @@ graph TD
 - GitLab rules → GitHub Actions `if:` conditions
 - GitLab services → GitHub Actions services configuration
 
-### Variable and Environment Mappings:
+### Variable and Environment Mappings
+
 - GitLab variables → GitHub Actions environment variables and secrets
 - GitLab predefined variables → GitHub context variables (`github.*`)
 - GitLab environments → GitHub Actions environments with protection rules
 - GitLab masked variables → GitHub Actions secrets
 - Project/group/instance variables → Repository/organization secrets and variables
 
-### Structural Changes:
+### Structural Changes
+
 - Expanded all include statements inline
 - Expanded all template references inline
 - Converted stage dependencies to job `needs:` dependencies
@@ -67,12 +75,14 @@ graph TD
 
 ## ✅ Validation Results
 
-### Linting Results:
+### Linting Results
+
 ```
 [VALIDATION_OUTPUT_ACTIONLINT]
 ```
 
-### Manual Verification Checklist:
+### Manual Verification Checklist
+
 - [x] YAML syntax validated
 - [x] All actions properly versioned with latest stable versions
 - [x] Job dependencies verified
@@ -110,14 +120,16 @@ graph TD
 
 ## 🔗 Variable and Secret Requirements
 
-### Required GitHub Secrets:
+### Required GitHub Secrets
+
 - `DATABASE_PASSWORD` - Database connection password (from GitLab masked variables)
 - `API_SECRET_KEY` - Application API secret key
 - `DEPLOYMENT_TOKEN` - Deployment service token
 - `DOCKER_PASSWORD` - Docker registry password
 - [List other project-specific secrets migrated from GitLab variables]
 
-### Required GitHub Variables:
+### Required GitHub Variables
+
 - `NODE_ENV` - Node.js environment configuration
 - `API_ENDPOINT` - Application API endpoint
 - `BUILD_CONFIGURATION` - Build configuration setting
@@ -140,6 +152,7 @@ graph TD
 ## 📁 Original GitLab CI/CD Files
 
 The original GitLab CI/CD pipeline files have been moved to `.github/ci-archive/` for reference:
+
 - `.gitlab-ci.yml` → [`.github/ci-archive/.gitlab-ci.yml`](.github/ci-archive/.gitlab-ci.yml)
 - Include files → [`.github/ci-archive/.gitlab/`](.github/ci-archive/.gitlab/)
 - Templates → [`.github/ci-archive/`](.github/ci-archive/) with preserved structure
@@ -153,3 +166,5 @@ The original GitLab CI/CD pipeline files have been moved to `.github/ci-archive/
 
 ---
 *Migration completed by GitHub Copilot GitLab CI/CD Migration Agent*
+
+````

--- a/knowledge/report-template/jenkins.md
+++ b/knowledge/report-template/jenkins.md
@@ -1,9 +1,8 @@
-## 📄 MIGRATION REPORT TEMPLATE
+# 📄 MIGRATION REPORT TEMPLATE
 
-Create `.github/ci-archive/MIGRATION-README.md` with this complete template:
+Use the following as the Pull Request body:
 
-```markdown
-
+````markdown
 # 🚀 Jenkins to GitHub Actions Migration Report
 
 ## 📊 Migration Overview
@@ -43,7 +42,8 @@ graph LR
 
 ## 🔧 Key Transformations
 
-### Stage and Step Conversions:
+### Stage and Step Conversions
+
 - Jenkins stages → GitHub Actions jobs with dependencies
 - Jenkins steps → GitHub Actions steps
 - `checkout scm` → `actions/checkout@v4`
@@ -51,12 +51,14 @@ graph LR
 - Groovy scripts → Shell scripts or marketplace actions
 - Custom pipeline steps → Combined job steps
 
-### Shared Library Expansions:
+### Shared Library Expansions
+
 - Jenkins shared library calls → Expanded inline with marketplace actions
 - Custom library functions → Shell scripts or GitHub Actions equivalents
 - Reusable pipeline components → Reusable workflows or composite actions
 
-### Credential and Environment Mappings:
+### Credential and Environment Mappings
+
 - Jenkins credentials → GitHub Secrets for sensitive data
 - Jenkins environment variables → GitHub Variables for non-sensitive configuration
 - Credential bindings → GitHub Actions secrets references
@@ -64,7 +66,8 @@ graph LR
 - `GIT_COMMIT` → `${{ github.sha }}`
 - `BRANCH_NAME` → `${{ github.ref_name }}`
 
-### Structural Changes:
+### Structural Changes
+
 - Combined sequential stages into single jobs where appropriate
 - Converted parallel stages to concurrent jobs
 - Improved caching with GitHub Actions cache
@@ -73,12 +76,14 @@ graph LR
 
 ## ✅ Validation Results
 
-### Linting Results:
+### Linting Results
+
 ```
 [VALIDATION_OUTPUT_ACTIONLINT]
 ```
 
-### Manual Verification Checklist:
+### Manual Verification Checklist
+
 - [x] YAML syntax validated
 - [x] All actions properly versioned
 - [x] Job dependencies verified
@@ -109,7 +114,8 @@ graph LR
 
 ## 🔗 Variable and Secret Requirements
 
-### Required GitHub Secrets:
+### Required GitHub Secrets
+
 - `DOCKER_USERNAME` - Docker Hub username (from Jenkins credentials)
 - `DOCKER_PASSWORD` - Docker Hub password
 - `AWS_ACCESS_KEY_ID` - AWS deployment credentials
@@ -117,7 +123,8 @@ graph LR
 - `SSH_PRIVATE_KEY` - SSH deployment key
 - [List other project-specific secrets migrated from Jenkins credentials]
 
-### Required GitHub Variables:
+### Required GitHub Variables
+
 - `BUILD_CONFIGURATION` - Build configuration setting
 - `DEPLOYMENT_ENVIRONMENT` - Target deployment environment
 - `ARTIFACT_VERSION` - Artifact versioning scheme
@@ -135,9 +142,10 @@ graph LR
 
 ## 📁 Original Jenkins Files
 
-The original Jenkins pipeline files have been moved to [`.github/ci-archive/`](.github/ci-archive/) for reference.
+The original Jenkins pipeline files have been moved to `.github/ci-archive/` for reference:
 
-For a complete record of this migration, see [MIGRATION-README.md](.github/ci-archive/MIGRATION-README.md) in the archive folder.
+- `Jenkinsfile` → [`.github/ci-archive/Jenkinsfile`](.github/ci-archive/Jenkinsfile)
+- Shared libraries → [`.github/ci-archive/vars/`](.github/ci-archive/vars/)
 
 ## 📚 Migration Notes
 
@@ -147,4 +155,5 @@ For a complete record of this migration, see [MIGRATION-README.md](.github/ci-ar
 
 ---
 *Migration completed by GitHub Copilot Jenkins Migration Agent*
-```
+
+````

--- a/knowledge/report-template/jenkins.md
+++ b/knowledge/report-template/jenkins.md
@@ -1,6 +1,6 @@
 # 📄 MIGRATION REPORT TEMPLATE
 
-Use the following as the Pull Request body:
+Use the following content both as the Pull Request body and as the contents of `.github/ci-archive/MIGRATION-README.md`:
 
 ````markdown
 # 🚀 Jenkins to GitHub Actions Migration Report

--- a/knowledge/report-template/travisci.md
+++ b/knowledge/report-template/travisci.md
@@ -1,9 +1,8 @@
-## 📄 MIGRATION REPORT TEMPLATE
+# 📄 MIGRATION REPORT TEMPLATE
 
-Create `.github/ci-archive/MIGRATION-README.md` with this complete template:
+Use the following as the Pull Request body:
 
-```markdown
-
+````markdown
 # 🚀 Travis CI to GitHub Actions Migration Report
 
 ## 📊 Migration Overview
@@ -45,19 +44,22 @@ graph LR
 
 ## 🔧 Key Transformations
 
-### Build Matrix Conversions:
+### Build Matrix Conversions
+
 - Travis CI build matrix → GitHub Actions matrix strategy
 - Language specifications → Setup actions (setup-node, setup-python, etc.)
 - Matrix environment variables → GitHub Actions matrix include/exclude
 - Global environment variables → Workflow-level env
 
-### Service and Infrastructure Mappings:
+### Service and Infrastructure Mappings
+
 - `services: postgresql` → `services.postgres` with health checks
 - `services: redis` → `services.redis` with health checks
 - `addons: apt` packages → `run` steps with apt-get install
 - `addons: chrome` → Browser setup actions
 
-### Deployment and Lifecycle Mappings:
+### Deployment and Lifecycle Mappings
+
 - Travis CI deployment providers → GitHub Actions deployment jobs
 - `before_install` → Pre-setup steps
 - `install` → Dependency installation steps
@@ -65,13 +67,15 @@ graph LR
 - `after_success` → Success condition steps with `if: success()`
 - `after_failure` → Failure condition steps with `if: failure()`
 
-### Environment Variable and Secret Mappings:
+### Environment Variable and Secret Mappings
+
 - Travis CI encrypted variables → GitHub Secrets for sensitive data
 - Travis CI environment variables → GitHub Variables for non-sensitive configuration
 - Environment-specific configuration → Repository or organization variables/secrets
 - Build metadata → GitHub context variables (`github.run_number`, etc.)
 
-### Structural Changes:
+### Structural Changes
+
 - Converted Travis CI build matrix to GitHub Actions matrix strategy
 - Enhanced caching with GitHub Actions cache
 - Enhanced security with proper secret and variable management
@@ -79,12 +83,14 @@ graph LR
 
 ## ✅ Validation Results
 
-### Linting Results:
+### Linting Results
+
 ```
 [VALIDATION_OUTPUT_ACTIONLINT]
 ```
 
-### Manual Verification Checklist:
+### Manual Verification Checklist
+
 - [x] YAML syntax validated
 - [x] All actions properly versioned
 - [x] Matrix strategy properly configured
@@ -117,14 +123,16 @@ graph LR
 
 ## 🔗 Variable and Secret Requirements
 
-### Required GitHub Secrets:
+### Required GitHub Secrets
+
 - `HEROKU_API_KEY` - Heroku deployment API key (from Travis CI encrypted variables)
 - `NPM_TOKEN` - NPM publishing token
 - `CODECOV_TOKEN` - Code coverage reporting token
 - `SLACK_WEBHOOK_URL` - Slack notification webhook
 - [List other project-specific secrets migrated from Travis CI encrypted variables]
 
-### Required GitHub Variables:
+### Required GitHub Variables
+
 - `NODE_ENV` - Node.js environment configuration
 - `API_ENDPOINT` - Application API endpoint
 - `BUILD_CONFIGURATION` - Build configuration setting
@@ -144,9 +152,9 @@ graph LR
 
 ## 📁 Original Travis CI Files
 
-The original Travis CI configuration files have been moved to [`.github/ci-archive/`](.github/ci-archive/) for reference.
+The original Travis CI configuration files have been moved to `.github/ci-archive/` for reference:
 
-For a complete record of this migration, see [MIGRATION-README.md](.github/ci-archive/MIGRATION-README.md) in the archive folder.
+- `.travis.yml` → [`.github/ci-archive/.travis.yml`](.github/ci-archive/.travis.yml)
 
 ## 📚 Migration Notes
 
@@ -157,4 +165,5 @@ For a complete record of this migration, see [MIGRATION-README.md](.github/ci-ar
 
 ---
 *Migration completed by GitHub Copilot Travis CI Migration Agent*
-```
+
+````

--- a/knowledge/report-template/travisci.md
+++ b/knowledge/report-template/travisci.md
@@ -1,6 +1,6 @@
 # 📄 MIGRATION REPORT TEMPLATE
 
-Use the following as the Pull Request body:
+Use the following content both as the Pull Request body and as the contents of `.github/ci-archive/MIGRATION-README.md` (they must stay in sync):
 
 ````markdown
 # 🚀 Travis CI to GitHub Actions Migration Report


### PR DESCRIPTION
This pull request updates the documentation and agent instructions to standardize and clarify the migration deliverables for Azure DevOps, Bamboo, and Bitbucket to GitHub Actions. The main change is that migration reports are now delivered as the body of a Pull Request (PR), rather than only as a file in the archive. The documentation has also been improved for clarity, completeness, and consistency across all migration agents.

