### PR TITLE
Add APM manifest as alternate install path (additive to plugin)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,8 @@ ENV/
 
 # Scratch folder
 scratch/
+# APM: generated / compiled output — produced on demand by `apm install` / `apm pack`.
+# The committed source of truth is the primitives under `plugin/` and `agents/` plus `apm.yml`.
+apm_modules/
+build/
+.agents/

--- a/README.md
+++ b/README.md
@@ -113,8 +113,10 @@ Add the dependency to your project's `apm.yml`:
 ```yaml
 dependencies:
   apm:
-    - github/actions-migrations-via-copilot#v1.2.0
+    - github/actions-migrations-via-copilot/plugin#v1.2.0
 ```
+
+The `/plugin` suffix is a **virtual path** — it points APM at the [`plugin/`](plugin/) subdirectory where `plugin.json` lives, so APM treats this repo as a *Plugin collection* package type ([APM docs](https://microsoft.github.io/apm/reference/package-types/#plugin-collection-pluginjson)) and dissects `plugin.json` to install the agents and skills.
 
 Then run:
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ copilot plugin install ./plugin
 
 ### Option C — Install via APM (pinned, hashed, auditable) *(experimental)*
 
-Use this when you need reproducible installs with lockfile-pinned versions, content-integrity scanning, SBOM export, or air-gapped operation — typical for regulated industries.
+Use this when you need reproducible installs with lockfile-pinned versions, content-integrity scanning, SBOM export, or **offline agent runtime** — typical for regulated industries. Install itself still requires network access to fetch the CLI and the pinned package, but once `apm install` resolves the dependency, all primitives land on disk in your repo — so the agent's runtime never fetches from a marketplace or plugin cache.
 
 Install the [APM CLI](https://microsoft.github.io/apm/) once:
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,50 @@ cd actions-migrations-via-copilot
 copilot plugin install ./plugin
 ```
 
+### Option C — Install via APM (pinned, hashed, auditable) *(experimental)*
+
+Use this when you need reproducible installs with lockfile-pinned versions, content-integrity scanning, SBOM export, or air-gapped operation — typical for regulated industries.
+
+Install the [APM CLI](https://microsoft.github.io/apm/) once:
+
+```bash
+curl -sSL https://aka.ms/apm-unix | sh      # macOS / Linux
+# irm https://aka.ms/apm-windows | iex        # Windows
+```
+
+Add the dependency to your project's `apm.yml`:
+
+```yaml
+dependencies:
+  apm:
+    - github/actions-migrations-via-copilot#v1.2.0
+```
+
+Then run:
+
+```bash
+apm install
+```
+
+APM deploys the agents and skills into your repo, pins the resolved sources and content hashes in `apm.lock.yaml`, and content-scans every primitive before it reaches disk.
+
+#### Why APM complements the plugin
+
+Plugin install and APM install solve different problems and are additive — most enterprises will use both.
+
+| Concern | Plugin (Options A/B) | APM (Option C) |
+| --- | --- | --- |
+| Control plane | GitHub Copilot admin UI + `.github-private` settings | `apm-policy.yml` in a policy repo (tighten-only inheritance) |
+| Version resolution | Whatever `main` (or the marketplace pointer) resolves to at runtime | Semver tag pinned in `apm.yml`, hash pinned in `apm.lock.yaml` |
+| Content integrity | — | Hidden-Unicode / prompt-injection scan on every install |
+| Tampering detection | — | `apm audit --ci` diffs on-disk primitives against lockfile hashes |
+| Audit trail | Enterprise audit log | Lockfile diff on every PR; `apm lock export --format cyclonedx\|spdx` (SBOM) |
+| Air-gapped / restricted network | Depends on marketplace reachability | Files land in the consumer repo — no runtime fetch |
+| Non-Copilot harnesses (Claude, Cursor, Codex, ...) | — | Same manifest deploys to every supported harness |
+| Zero-touch enablement | Admin flips a toggle in the enterprise console | Consumer commits `apm.yml` and runs `apm install` (or CI does) |
+
+**Recommended pattern:** use plugin install as the primary, frictionless path (GitHub-native, admin-toggleable); layer APM on top for regulated or air-gapped repos that need lockfile provenance, content-integrity scanning, or SBOMs. Both paths ship the same agents and skills — only the delivery and governance surface differs.
+
 ---
 
 ## How Migration Works

--- a/README.md
+++ b/README.md
@@ -124,23 +124,6 @@ apm install
 
 APM deploys the agents and skills into your repo, pins the resolved sources and content hashes in `apm.lock.yaml`, and content-scans every primitive before it reaches disk.
 
-#### Why APM complements the plugin
-
-Plugin install and APM install solve different problems and are additive — most enterprises will use both.
-
-| Concern | Plugin (Options A/B) | APM (Option C) |
-| --- | --- | --- |
-| Control plane | GitHub Copilot admin UI + `.github-private` settings | `apm-policy.yml` in a policy repo (tighten-only inheritance) |
-| Version resolution | Whatever `main` (or the marketplace pointer) resolves to at runtime | Semver tag pinned in `apm.yml`, hash pinned in `apm.lock.yaml` |
-| Content integrity | — | Hidden-Unicode / prompt-injection scan on every install |
-| Tampering detection | — | `apm audit --ci` diffs on-disk primitives against lockfile hashes |
-| Audit trail | Enterprise audit log | Lockfile diff on every PR; `apm lock export --format cyclonedx\|spdx` (SBOM) |
-| Air-gapped / restricted network | Depends on marketplace reachability | Files land in the consumer repo — no runtime fetch |
-| Non-Copilot harnesses (Claude, Cursor, Codex, ...) | — | Same manifest deploys to every supported harness |
-| Zero-touch enablement | Admin flips a toggle in the enterprise console | Consumer commits `apm.yml` and runs `apm install` (or CI does) |
-
-**Recommended pattern:** use plugin install as the primary, frictionless path (GitHub-native, admin-toggleable); layer APM on top for regulated or air-gapped repos that need lockfile provenance, content-integrity scanning, or SBOMs. Both paths ship the same agents and skills — only the delivery and governance surface differs.
-
 ---
 
 ## How Migration Works

--- a/README.md
+++ b/README.md
@@ -104,8 +104,13 @@ Use this when you need reproducible installs with lockfile-pinned versions, cont
 Install the [APM CLI](https://microsoft.github.io/apm/) once:
 
 ```bash
-curl -sSL https://aka.ms/apm-unix | sh      # macOS / Linux
-# irm https://aka.ms/apm-windows | iex        # Windows
+# macOS / Linux
+curl -sSL https://aka.ms/apm-unix | sh
+```
+
+```powershell
+# Windows
+irm https://aka.ms/apm-windows | iex
 ```
 
 Add the dependency to your project's `apm.yml`:

--- a/apm.yml
+++ b/apm.yml
@@ -22,7 +22,9 @@ keywords:
 - reusable-workflows
 targets:
 - copilot
-includes: auto
+includes:
+- plugin/agents
+- plugin/skills
 dependencies:
   apm: []
   mcp: []

--- a/apm.yml
+++ b/apm.yml
@@ -22,9 +22,7 @@ keywords:
 - reusable-workflows
 targets:
 - copilot
-includes:
-- plugin/agents
-- plugin/skills
+includes: auto
 dependencies:
   apm: []
   mcp: []

--- a/apm.yml
+++ b/apm.yml
@@ -1,0 +1,31 @@
+name: actions-migrator
+version: 1.2.0
+description: Enterprise-grade GitHub Copilot agents that migrate CI/CD pipelines
+  from Jenkins, Azure DevOps, CircleCI, GitLab, Travis CI, Bamboo, Bitbucket
+  Pipelines, and Drone CI to GitHub Actions.
+author: GitHub Professional Services
+repository: https://github.com/github/actions-migrations-via-copilot
+homepage: https://github.com/github/actions-migrations-via-copilot
+license: MIT
+keywords:
+- github-actions
+- ci-cd
+- migration
+- jenkins
+- azure-devops
+- circleci
+- gitlab
+- travis-ci
+- bamboo
+- bitbucket
+- drone-ci
+- reusable-workflows
+targets:
+- copilot
+includes: auto
+dependencies:
+  apm: []
+  mcp: []
+devDependencies:
+  apm: []
+scripts: {}


### PR DESCRIPTION
## What is APM?

[APM (Agent Package Manager)](https://github.com/microsoft/apm) is an open-source dependency manager for AI agent primitives — skills, prompts, instructions, hooks, agents, MCP servers. Think `npm install` but for agent configuration. One `apm.yml` describes everything an agent needs; `apm install` reproduces it deterministically on any machine, with content hashes pinned in `apm.lock.yaml`.

## How it complements the plugin

Plugin install and APM install are **additive, not competing** — they operate at different layers:

- **Plugin** = the runtime bundle Copilot loads (agents/skills/hooks). Distributed via the Copilot marketplace and enabled centrally through the enterprise console + `.github-private/.github/copilot/settings.json`. Frictionless, GitHub-native, zero developer action.
- **APM** = the install/governance layer *around* those primitives. Files land in the consumer repo, pinned by hash, content-scanned, auditable in every PR.

## The 4-layer defense-in-depth model

APM + hooks (from #33) together give you distinct checks at four moments in the agent lifecycle:

| Moment | Layer | Check | Blocks |
|---|---|---|---|
| **Author-time** | APM producer | Schema validation | Malformed packages |
| **Install-time** | APM CLI | Content-integrity scan + policy | Hidden Unicode, prompt-injection payloads, disallowed sources, unpinned refs |
| **PR-time** | `apm audit --ci` | Drift / hash-mismatch check | Tampering with materialized primitives, hand-edits, sneaky diff |
| **Runtime** | Copilot hooks (#33) | `preToolUse` / `postToolUse` policy | Bad tool calls at execution (destructive writes, secret exfil, MCP alt-paths) |

Plugin marketplace install gives you **layer 4 only** (once #33 lands). APM adds layers 1–3. That's the "regulated customers" pitch: defense in depth across the whole lifecycle, not just runtime.

**Runtime hooks (PR #33) remain the enforcement point** — APM never gates tool calls at execution. It stops bad code from reaching the agent; hooks stop the agent from doing bad things with the code it has.

### When APM adds value

- **Regulated customer (bank, gov, healthcare)** — needs SBOM, lockfile provenance, tamper detection. `apm lock export --format cyclonedx` gives auditors a standard inventory of every prompt/skill an agent can see.
- **Air-gapped / restricted network** — the migration plugin files land in the consumer repo at install time, so no marketplace fetch is needed at runtime.
- **Customer wants to customize skills** — they fork, publish their own APM package, and their own `apm-policy.yml` restricts what other teams in their org can install on top of it.
- **Multi-vendor AI stack** — same `apm.yml` also configures Claude, Cursor, Codex, and others. Nothing else on the market does this today.
- **Reproducibility** — `main` moves; a pinned tag + content hash doesn't. Consumers don't get silently upgraded when we push to `main`.

### Additional capabilities worth noting

- **`apm outdated`** — surfaces which pinned deps have newer versions available. Explicit updates, not automatic drift.
- **Selective skill install** — `apm install .../plugin --skill jenkins-migration --skill actionlint` cherry-picks; reduces attack surface.
- **Enterprise policy (`apm-policy.yml`)** — org-level rules (`require_pinned_version`, `allowed_sources`, `require_explicit_includes`) with tighten-only inheritance from enterprise → org → repo. Wired into `apm audit --ci`, so PRs that violate policy fail before merge.
- **MCP-server trust prompts** — transitive MCP servers require explicit consent; prevents *"install skill X, get a hidden MCP server that reads your GitHub token"* supply-chain attacks.
- **Deployment ledger** — records *who* deployed *what* and *when*, separate from the lockfile. Audit trail for change-control.

## How to test

The APM CLI is client-side, so testing is a one-liner in any scratch repo. Verified end-to-end against `feat/apm-manifest` at commit `33d7d80`:

```bash
# Install the APM CLI once
curl -sSL https://aka.ms/apm-unix | sh

# In a fresh test repo
mkdir /tmp/apm-migrator-test && cd /tmp/apm-migrator-test
git init
cat > apm.yml <<'YAML'
name: apm-migrator-test
version: 0.0.1
targets: [copilot]
dependencies:
  apm:
    - github/actions-migrations-via-copilot/plugin#feat/apm-manifest
YAML

apm install     # 9 agents + 11 skills materialized, apm.lock.yaml written
apm audit --ci  # 10/10 integrity checks pass on a fresh install
```

**Note the `/plugin` suffix on the dependency spec** — that's a virtual path pointing at the subdirectory where `plugin.json` lives. APM recognizes this as a *Plugin collection* package type ([APM docs](https://microsoft.github.io/apm/reference/package-types/#plugin-collection-pluginjson)) and dissects `plugin.json` to install the agents and skills. Zero producer refactor required.

Once merged and a tag (e.g. `v1.3.0`) is cut, the dependency line becomes `github/actions-migrations-via-copilot/plugin#v1.3.0`.

### Enforcement demos (verified locally)

**Drift detection catches tampering.** Modified a materialized skill file, `apm audit --ci` failed with:
```
content-integrity: 1 file(s) with hash drift
  hash-drift: .agents/skills/jenkins-migration/SKILL.md
  expected=fedf7085c7b9..., actual=6fe2322e9af7...
[x] 2 of 9 check(s) failed
```
Wire this into a `.github/workflows/apm-audit.yml` and tampered PRs never merge.

**SBOM export works out of the box:**
```
apm lock export --format cyclonedx  # or spdx
```
Produces an industry-standard bill of materials with the resolved commit SHA baked into the purl. Zero effort for procurement/compliance.

## Scope

- `apm.yml` (new, minimal) — declares `actions-migrator@1.2.0`, `targets: copilot`. APM ignores this at install time (uses `plugin/plugin.json` via virtual path) but kept for future `marketplace:` block authoring.
- `README.md` — new **Option C — Install via APM** subsection alongside existing Options A/B, documents the `/plugin` virtual-path syntax.
- `.gitignore` — append APM-generated paths (`apm_modules/`, `build/`, `.agents/`).

No behavior change to the plugin runtime. Additive only. Zero file overlap with #33.

## Deferred to follow-ups

- Commit `apm.lock.yaml` (needs `apm install` from a maintainer)
- `.github/workflows/apm-audit.yml` for `apm audit --ci` on every PR
- `docs/enterprise/apm-policy-example.yml`
- After #33 merges, evaluate whether hooks should also ship as an APM primitive (they already work via plugin channel)

## Refs

- APM: https://github.com/microsoft/apm
- Package types: https://microsoft.github.io/apm/reference/package-types/
- Reference producer PR: https://github.com/github/expert-services-agent-skill/pull/3
- Companion runtime-enforcement PR: #33
